### PR TITLE
Adds an `OnBeforeDying` listener and captures death edge case

### DIFF
--- a/pkg/engine/modifier/listener.go
+++ b/pkg/engine/modifier/listener.go
@@ -42,6 +42,9 @@ type Listeners struct {
 	// prevent the TargetDeathEvent from occuring. Used by revives.
 	OnLimboWaitHeal func(mod *ModifierInstance) bool
 
+	// Called when the attached target has taken fatal damage and no revive will occur.
+	OnBeforeDying func(mod *ModifierInstance)
+
 	// Called when the attached target kills another target. The given target ID is the target that
 	// has been killed.
 	OnTriggerDeath func(mod *ModifierInstance, target key.TargetID)
@@ -410,6 +413,13 @@ func (mgr *Manager) limboWaitHeal(e event.LimboWaitHealEvent) bool {
 }
 
 func (mgr *Manager) targetDeath(e event.TargetDeathEvent) {
+	for _, mod := range mgr.targets[e.Target] {
+		f := mod.listeners.OnBeforeDying
+		if f != nil {
+			f(mod)
+		}
+	}
+
 	for _, mod := range mgr.targets[e.Killer] {
 		f := mod.listeners.OnTriggerDeath
 		if f != nil {

--- a/pkg/simulation/helper.go
+++ b/pkg/simulation/helper.go
@@ -1,0 +1,50 @@
+package simulation
+
+import (
+	"github.com/simimpact/srsim/pkg/engine/event"
+	"github.com/simimpact/srsim/pkg/engine/info"
+	"github.com/simimpact/srsim/pkg/key"
+)
+
+type snapshot struct {
+	characters []*info.Stats
+	enemies    []*info.Stats
+	neutrals   []*info.Stats
+}
+
+func (s *simulation) createSnapshot() snapshot {
+	charStats := make([]*info.Stats, len(s.characters))
+	for i, t := range s.characters {
+		charStats[i] = s.attr.Stats(t)
+	}
+	enemyStats := make([]*info.Stats, len(s.enemies))
+	for i, t := range s.enemies {
+		enemyStats[i] = s.attr.Stats(t)
+	}
+	neutralStats := make([]*info.Stats, len(s.neutrals))
+	for i, t := range s.neutrals {
+		neutralStats[i] = s.attr.Stats(t)
+	}
+	return snapshot{
+		characters: charStats,
+		enemies:    enemyStats,
+		neutrals:   neutralStats,
+	}
+}
+
+// This is for handling a special case where a target should be dead but is not.
+// atm the only scenario where this can occur is if a target was scheduled to be revived but then
+// the reviver died/was incapacitated and the revive was cancelled.
+//
+// Due to the current sim control flow, the information about who killed this target has been lost.
+// Emitting event that this death was a suicide, which is not the ideal behavior
+func (s *simulation) deathCheck(targets []key.TargetID) {
+	for _, target := range targets {
+		if s.attr.HPRatio(target) <= 0 {
+			s.event.TargetDeath.Emit(event.TargetDeathEvent{
+				Target: target,
+				Killer: target,
+			})
+		}
+	}
+}


### PR DESCRIPTION
* Adds `OnBeforeDying` listener for https://github.com/simimpact/srsim/issues/19 (still need to update implementations)
* Added death checks on `endTurn` to ensure targets at 0 HP are marked as dead
* Cleaned up stats generation in `BattleStartEvent` and `TurnEndEvent`