### PR TITLE
fix silverwolf talent when all bugs applied

### DIFF
--- a/internal/character/silverwolf/talent.go
+++ b/internal/character/silverwolf/talent.go
@@ -78,6 +78,10 @@ func newRandomBug(engine engine.Engine, target key.TargetID, source key.TargetID
 			bugs = append(bugs, b)
 		}
 	}
+	// if all bugs on target, application is random
+	if len(bugs) == 0 {
+		bugs = []key.Modifier{BugATK, BugDEF, BugSPD}
+	}
 	duration := 3
 	if char.Traces["1006101"] {
 		duration += 1


### PR DESCRIPTION
Silver Wolf should apply bugs randomly if she has already applied all three of her bugs to a target.