### PR TITLE
Fixed Arlan E6 condition

### DIFF
--- a/internal/character/arlan/ult.go
+++ b/internal/character/arlan/ult.go
@@ -31,7 +31,7 @@ func (c *char) Ult(target key.TargetID, state info.ActionState) {
 		// Adjacent Targets
 		additionalMod := 0.5
 
-		if c.info.Eidolon >= 6 {
+		if c.info.Eidolon >= 6 && c.engine.HPRatio(c.id) <= 0.5 {
 			additionalMod = 1
 		}
 


### PR DESCRIPTION
The base damage bonus only applies if Arlan is below 50% hp