### PR TITLE
Removing Event suffix from all event names

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,7 +79,7 @@ linters-settings:
     - 'github\.com/simimpact/srsim/pkg/engine/modifier\.Config'
     - 'github\.com/simimpact/srsim/pkg/engine/modifier\.Listeners'
     - 'github\.com/simimpact/srsim/pkg/engine/modifier\.Instance'
-    - 'github\.com/simimpact/srsim/pkg/engine/event'
+    - 'github\.com/simimpact/srsim/pkg/engine/event\.System'
     - 'github\.com/simimpact/srsim/pkg/model'
     - 'github\.com/simimpact/srsim/pkg/gcs'
     - 'github\.com/simimpact/srsim/pkg/simulation'

--- a/internal/character/arlan/eidolon.go
+++ b/internal/character/arlan/eidolon.go
@@ -19,7 +19,7 @@ func init() {
 	// When HP is lower than or equal to 50% of Max HP, increases Skill's DMG by 10%.
 	modifier.Register(E1, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnBeforeHit: func(mod *modifier.Instance, e event.HitStartEvent) {
+			OnBeforeHit: func(mod *modifier.Instance, e event.HitStart) {
 				if e.Hit.AttackType != model.AttackType_SKILL {
 					return
 				}
@@ -66,7 +66,7 @@ func init() {
 	// DMG taken by the target enemy now applies to adjacent enemies as well.
 	modifier.Register(E6, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnBeforeHit: func(mod *modifier.Instance, e event.HitStartEvent) {
+			OnBeforeHit: func(mod *modifier.Instance, e event.HitStart) {
 				if e.Hit.AttackType != model.AttackType_ULT {
 					return
 				}

--- a/internal/character/arlan/talent.go
+++ b/internal/character/arlan/talent.go
@@ -29,7 +29,7 @@ func init() {
 			},
 
 			// update bonus damage based on new HP
-			OnHPChange: func(mod *modifier.Instance, e event.HPChangeEvent) {
+			OnHPChange: func(mod *modifier.Instance, e event.HPChange) {
 				addedBonusDamage := (1 - mod.Engine().HPRatio(mod.Owner())) * mod.State().(talentState).maxBonusDamage
 				mod.SetProperty(prop.AllDamagePercent, addedBonusDamage)
 			},

--- a/internal/character/arlan/trace.go
+++ b/internal/character/arlan/trace.go
@@ -43,7 +43,7 @@ func init() {
 			OnAdd: func(mod *modifier.Instance) {
 				// TODO: https://github.com/simimpact/srsim/issues/13
 			},
-			OnAfterBeingAttacked: func(mod *modifier.Instance, e event.AttackEndEvent) {
+			OnAfterBeingAttacked: func(mod *modifier.Instance, e event.AttackEnd) {
 				mod.RemoveSelf()
 			},
 		},

--- a/internal/character/bronya/eidolon.go
+++ b/internal/character/bronya/eidolon.go
@@ -19,7 +19,7 @@ const (
 func init() {
 	modifier.Register(E2Hover, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnAfterAction: func(mod *modifier.Instance, e event.ActionEndEvent) {
+			OnAfterAction: func(mod *modifier.Instance, e event.ActionEnd) {
 				mod.Engine().AddModifier(mod.Owner(), info.Modifier{
 					Name:   E2Buff,
 					Source: mod.Source(),

--- a/internal/character/bronya/eidolon.go
+++ b/internal/character/bronya/eidolon.go
@@ -70,7 +70,7 @@ func (c *char) e2(target key.TargetID) {
 	}
 }
 
-func (c *char) e4Listener(e event.AttackEndEvent) {
+func (c *char) e4Listener(e event.AttackEnd) {
 	// Assumed to be E4+ from subscription
 
 	// has to be Ally Attacker

--- a/internal/character/bronya/eidolon.go
+++ b/internal/character/bronya/eidolon.go
@@ -19,7 +19,7 @@ const (
 func init() {
 	modifier.Register(E2Hover, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnAfterAction: func(mod *modifier.Instance, e event.ActionEvent) {
+			OnAfterAction: func(mod *modifier.Instance, e event.ActionEndEvent) {
 				mod.Engine().AddModifier(mod.Owner(), info.Modifier{
 					Name:   E2Buff,
 					Source: mod.Source(),

--- a/internal/character/bronya/trace.go
+++ b/internal/character/bronya/trace.go
@@ -77,7 +77,7 @@ func (c *char) initTraces() {
 			})
 		}
 
-		c.engine.Events().CharacterAdded.Subscribe(func(e event.CharacterAddedEvent) {
+		c.engine.Events().CharacterAdded.Subscribe(func(e event.CharacterAdded) {
 			c.engine.AddModifier(e.ID, info.Modifier{
 				Name:   A4,
 				Source: c.id,
@@ -96,7 +96,7 @@ func (c *char) initTraces() {
 			})
 		}
 
-		c.engine.Events().CharacterAdded.Subscribe(func(e event.CharacterAddedEvent) {
+		c.engine.Events().CharacterAdded.Subscribe(func(e event.CharacterAdded) {
 			c.engine.AddModifier(e.ID, info.Modifier{
 				Name:   A6,
 				Source: c.id,

--- a/internal/character/bronya/trace.go
+++ b/internal/character/bronya/trace.go
@@ -19,7 +19,7 @@ func init() {
 	// A2 Register
 	modifier.Register(A2, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnBeforeHit: func(mod *modifier.Instance, e event.HitStartEvent) {
+			OnBeforeHit: func(mod *modifier.Instance, e event.HitStart) {
 				if e.Hit.AttackType == model.AttackType_NORMAL {
 					e.Hit.Attacker.AddProperty(prop.CritChance, 1)
 				}

--- a/internal/character/danheng/danheng.go
+++ b/internal/character/danheng/danheng.go
@@ -52,7 +52,6 @@ func NewInstance(engine engine.Engine, id key.TargetID, charInfo info.Character)
 
 	// for talent to modifier when Dan Heng is targetted by ally action
 	engine.Events().ActionEnd.Subscribe(c.talentActionEndListener)
-	engine.Events().UltEnd.Subscribe(c.talentActionEndListener)
 
 	c.initTraces()
 	c.initEidolons()

--- a/internal/character/danheng/eidolon.go
+++ b/internal/character/danheng/eidolon.go
@@ -17,7 +17,7 @@ func init() {
 	// When the target enemy's current HP percentage is greater than or equal to 50%, CRIT Rate increases by 12%.
 	modifier.Register(E1, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnBeforeHitAll: func(mod *modifier.Instance, e event.HitStartEvent) {
+			OnBeforeHitAll: func(mod *modifier.Instance, e event.HitStart) {
 				if e.Hit.Defender.CurrentHPRatio() >= 0.5 {
 					e.Hit.Attacker.AddProperty(prop.CritChance, 0.12)
 				}

--- a/internal/character/danheng/skill.go
+++ b/internal/character/danheng/skill.go
@@ -23,7 +23,7 @@ func init() {
 
 	modifier.Register(SkillCritCheck, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnAfterHit: func(mod *modifier.Instance, e event.HitEndEvent) {
+			OnAfterHit: func(mod *modifier.Instance, e event.HitEnd) {
 				if e.IsCrit {
 					slowAmt := mod.State().(float64)
 					mod.Engine().AddModifier(e.Defender, info.Modifier{

--- a/internal/character/danheng/talent.go
+++ b/internal/character/danheng/talent.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 // subscribe to all action ends to see if dan heng was ever the target of an ally action
-func (c *char) talentActionEndListener(e event.ActionEvent) {
+func (c *char) talentActionEndListener(e event.ActionEndEvent) {
 	// must be an ally (neutral targets dont count)
 	if !c.engine.IsCharacter(e.Owner) {
 		return
@@ -78,7 +78,7 @@ func talentBeforeHitAll(mod *modifier.Instance, e event.HitStartEvent) {
 }
 
 // after buffed action completes, add CD and remove talent buff
-func talentAfterAction(mod *modifier.Instance, e event.ActionEvent) {
+func talentAfterAction(mod *modifier.Instance, e event.ActionEndEvent) {
 	state := mod.State().(talentState)
 
 	mod.Engine().AddModifier(mod.Owner(), info.Modifier{

--- a/internal/character/danheng/talent.go
+++ b/internal/character/danheng/talent.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 // subscribe to all action ends to see if dan heng was ever the target of an ally action
-func (c *char) talentActionEndListener(e event.ActionEndEvent) {
+func (c *char) talentActionEndListener(e event.ActionEnd) {
 	// must be an ally (neutral targets dont count)
 	if !c.engine.IsCharacter(e.Owner) {
 		return
@@ -78,7 +78,7 @@ func talentBeforeHitAll(mod *modifier.Instance, e event.HitStartEvent) {
 }
 
 // after buffed action completes, add CD and remove talent buff
-func talentAfterAction(mod *modifier.Instance, e event.ActionEndEvent) {
+func talentAfterAction(mod *modifier.Instance, e event.ActionEnd) {
 	state := mod.State().(talentState)
 
 	mod.Engine().AddModifier(mod.Owner(), info.Modifier{

--- a/internal/character/danheng/talent.go
+++ b/internal/character/danheng/talent.go
@@ -66,7 +66,7 @@ func (c *char) talentActionEndListener(e event.ActionEnd) {
 	})
 }
 
-func talentBeforeHitAll(mod *modifier.Instance, e event.HitStartEvent) {
+func talentBeforeHitAll(mod *modifier.Instance, e event.HitStart) {
 	state := mod.State().(talentState)
 
 	/// only give pen to normal, skill, and ult hits. pursued will not be buffed

--- a/internal/character/danheng/trace.go
+++ b/internal/character/danheng/trace.go
@@ -50,7 +50,7 @@ func init() {
 
 	modifier.Register(A6, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnBeforeHit: func(mod *modifier.Instance, e event.HitStartEvent) {
+			OnBeforeHit: func(mod *modifier.Instance, e event.HitStart) {
 				if e.Hit.AttackType != model.AttackType_NORMAL {
 					return
 				}

--- a/internal/character/danheng/trace.go
+++ b/internal/character/danheng/trace.go
@@ -28,7 +28,7 @@ func init() {
 	modifier.Register(A2Check, modifier.Config{
 		Listeners: modifier.Listeners{
 			OnAdd: a2HPCheck,
-			OnHPChange: func(mod *modifier.Instance, e event.HPChangeEvent) {
+			OnHPChange: func(mod *modifier.Instance, e event.HPChange) {
 				a2HPCheck(mod)
 			},
 		},

--- a/internal/character/gepard/eidolon.go
+++ b/internal/character/gepard/eidolon.go
@@ -69,7 +69,7 @@ func (c *char) e4() {
 			})
 		}
 
-		c.engine.Events().CharacterAdded.Subscribe(func(e event.CharacterAddedEvent) {
+		c.engine.Events().CharacterAdded.Subscribe(func(e event.CharacterAdded) {
 			c.engine.AddModifier(e.ID, info.Modifier{
 				Name:   E4,
 				Source: c.id,

--- a/internal/character/gepard/eidolon.go
+++ b/internal/character/gepard/eidolon.go
@@ -44,7 +44,7 @@ func init() {
 
 func (c *char) e2() {
 	if c.info.Eidolon >= 2 {
-		c.engine.Events().ModifierRemoved.Subscribe(func(event event.ModifierRemovedEvent) {
+		c.engine.Events().ModifierRemoved.Subscribe(func(event event.ModifierRemoved) {
 			if event.Modifier.Name == common.Freeze && c.engine.HasModifier(event.Target, E2Tracker) {
 				c.engine.AddModifier(event.Target, info.Modifier{
 					Name:   E2,

--- a/internal/character/pela/eidolon.go
+++ b/internal/character/pela/eidolon.go
@@ -47,7 +47,7 @@ func init() {
 	modifier.Register(E6, modifier.Config{
 		Stacking: modifier.ReplaceBySource,
 		Listeners: modifier.Listeners{
-			OnAfterAttack: func(mod *modifier.Instance, e event.AttackEndEvent) {
+			OnAfterAttack: func(mod *modifier.Instance, e event.AttackEnd) {
 				for _, trg := range e.Targets {
 					if mod.Engine().ModifierCount(trg, model.StatusType_STATUS_DEBUFF) >= 1 {
 						mod.Engine().Attack(info.Attack{

--- a/internal/character/pela/talent.go
+++ b/internal/character/pela/talent.go
@@ -16,7 +16,7 @@ const (
 func init() {
 	modifier.Register(Talent, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnAfterAttack: func(mod *modifier.Instance, e event.AttackEndEvent) {
+			OnAfterAttack: func(mod *modifier.Instance, e event.AttackEnd) {
 				char, _ := mod.Engine().CharacterInfo(mod.Owner())
 				for _, trg := range e.Targets {
 					if mod.Engine().ModifierCount(trg, model.StatusType_STATUS_DEBUFF) >= 1 {

--- a/internal/character/pela/trace.go
+++ b/internal/character/pela/trace.go
@@ -25,7 +25,7 @@ const (
 func init() {
 	modifier.Register(A2, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnBeforeHitAll: func(mod *modifier.Instance, e event.HitStartEvent) {
+			OnBeforeHitAll: func(mod *modifier.Instance, e event.HitStart) {
 				if mod.Engine().ModifierCount(e.Hit.Defender.ID(), model.StatusType_STATUS_DEBUFF) >= 1 {
 					e.Hit.Attacker.AddProperty(prop.AllDamagePercent, 0.2)
 				}
@@ -52,10 +52,10 @@ func init() {
 
 	modifier.Register(A6, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnBeforeHitAll: func(mod *modifier.Instance, e event.HitStartEvent) {
+			OnBeforeHitAll: func(mod *modifier.Instance, e event.HitStart) {
 				e.Hit.Attacker.AddProperty(prop.AllDamagePercent, 0.2)
 			},
-			OnAfterAttack: func(mod *modifier.Instance, e event.AttackEndEvent) {
+			OnAfterAttack: func(mod *modifier.Instance, e event.AttackEnd) {
 				mod.RemoveSelf()
 			},
 		},

--- a/internal/character/pela/trace.go
+++ b/internal/character/pela/trace.go
@@ -86,7 +86,7 @@ func (c *char) initTraces() {
 				Source: c.id,
 			})
 		}
-		c.engine.Events().CharacterAdded.Subscribe(func(e event.CharacterAddedEvent) {
+		c.engine.Events().CharacterAdded.Subscribe(func(e event.CharacterAdded) {
 			c.engine.AddModifier(e.ID, info.Modifier{
 				Name:   A4,
 				Source: c.id,

--- a/internal/character/qingque/eidolon.go
+++ b/internal/character/qingque/eidolon.go
@@ -17,7 +17,7 @@ const (
 func init() {
 	modifier.Register(E1, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnBeforeHit: func(mod *modifier.Instance, e event.HitStartEvent) {
+			OnBeforeHit: func(mod *modifier.Instance, e event.HitStart) {
 				if e.Hit.AttackType != model.AttackType_ULT {
 					return
 				}

--- a/internal/character/qingque/talent.go
+++ b/internal/character/qingque/talent.go
@@ -19,7 +19,7 @@ func init() {
 	})
 }
 
-func (c *char) talentTurnStartListener(e event.TurnStartEvent) {
+func (c *char) talentTurnStartListener(e event.TurnStart) {
 	if c.engine.IsCharacter(e.Active) {
 		c.drawTile()
 	}

--- a/internal/character/qingque/trace.go
+++ b/internal/character/qingque/trace.go
@@ -42,7 +42,7 @@ func (c *char) initTraces() {
 	}
 }
 
-func A2ActionEndListener(mod *modifier.Instance, e event.ActionEndEvent) {
+func A2ActionEndListener(mod *modifier.Instance, e event.ActionEnd) {
 	if e.AttackType == model.AttackType_SKILL {
 		mod.Engine().ModifySP(1)
 		mod.RemoveSelf()

--- a/internal/character/qingque/trace.go
+++ b/internal/character/qingque/trace.go
@@ -42,7 +42,7 @@ func (c *char) initTraces() {
 	}
 }
 
-func A2ActionEndListener(mod *modifier.Instance, e event.ActionEvent) {
+func A2ActionEndListener(mod *modifier.Instance, e event.ActionEndEvent) {
 	if e.AttackType == model.AttackType_SKILL {
 		mod.Engine().ModifySP(1)
 		mod.RemoveSelf()

--- a/internal/character/sampo/eidolon.go
+++ b/internal/character/sampo/eidolon.go
@@ -5,7 +5,7 @@ import (
 	"github.com/simimpact/srsim/pkg/model"
 )
 
-func (c *char) E2TargetDeathListener(e event.TargetDeathEvent) {
+func (c *char) E2TargetDeathListener(e event.TargetDeath) {
 	if c.engine.HPRatio(c.id) <= 0 {
 		return
 	}

--- a/internal/character/sampo/talent.go
+++ b/internal/character/sampo/talent.go
@@ -25,7 +25,7 @@ func init() {
 // Enemies inflicted with Wind Shear will take Wind DoT equal to 20% of Sampo's ATK at the beginning of each turn. Wind Shear can stack up to 5 time(s).
 // Tree01 add 1 duration
 // Rank06 adds DamagePercentegeAdd
-func onAfterHit(mod *modifier.Instance, e event.HitEndEvent) {
+func onAfterHit(mod *modifier.Instance, e event.HitEnd) {
 	char, _ := mod.Engine().CharacterInfo(e.Attacker)
 	duration := 3
 	AddWindShearTalent(char, mod.Engine(), e.Attacker, e.Defender, duration, 0.65)

--- a/internal/character/sampo/trace.go
+++ b/internal/character/sampo/trace.go
@@ -27,7 +27,7 @@ func (c *char) a4() {
 	}
 }
 
-func A6OnBeforeBeingHitAll(mod *modifier.Instance, e event.HitStartEvent) {
+func A6OnBeforeBeingHitAll(mod *modifier.Instance, e event.HitStart) {
 	if mod.Engine().HasBehaviorFlag(e.Hit.Attacker.ID(), model.BehaviorFlag_STAT_DOT_POISON) {
 		e.Hit.Attacker.AddProperty(prop.Fatigue, 0.15)
 	}

--- a/internal/character/sampo/ult.go
+++ b/internal/character/sampo/ult.go
@@ -56,7 +56,7 @@ func (c *char) Ult(target key.TargetID, state info.ActionState) {
 	}
 }
 
-func onBeforeBeingHitAll(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeBeingHitAll(mod *modifier.Instance, e event.HitStart) {
 	if e.Hit.AttackType == model.AttackType_DOT {
 		e.Hit.Defender.AddProperty(prop.AllDamageTaken, mod.State().(float64))
 	}

--- a/internal/character/silverwolf/eidolon.go
+++ b/internal/character/silverwolf/eidolon.go
@@ -90,7 +90,7 @@ func (c *char) initEidolons() {
 			})
 		})
 
-		c.engine.Events().TargetDeath.Subscribe(func(event event.TargetDeathEvent) {
+		c.engine.Events().TargetDeath.Subscribe(func(event event.TargetDeath) {
 			if event.Target == c.id {
 				targets := c.engine.Enemies()
 

--- a/internal/character/silverwolf/eidolon.go
+++ b/internal/character/silverwolf/eidolon.go
@@ -83,7 +83,7 @@ func (c *char) e4(target key.TargetID) {
 
 func (c *char) initEidolons() {
 	if c.info.Eidolon >= 2 {
-		c.engine.Events().EnemyAdded.Subscribe(func(e event.EnemyAddedEvent) {
+		c.engine.Events().EnemyAdded.Subscribe(func(e event.EnemyAdded) {
 			c.engine.AddModifier(e.ID, info.Modifier{
 				Name:   E2,
 				Source: c.id,

--- a/internal/character/silverwolf/eidolon.go
+++ b/internal/character/silverwolf/eidolon.go
@@ -33,7 +33,7 @@ func init() {
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_DEBUFF,
 		Listeners: modifier.Listeners{
-			OnBeforeHitAll: func(mod *modifier.Instance, e event.HitStartEvent) {
+			OnBeforeHitAll: func(mod *modifier.Instance, e event.HitStart) {
 				debuffCount := mod.Engine().ModifierCount(e.Defender, model.StatusType_STATUS_DEBUFF)
 				if debuffCount > 5 {
 					debuffCount = 5

--- a/internal/character/silverwolf/talent.go
+++ b/internal/character/silverwolf/talent.go
@@ -55,7 +55,7 @@ func init() {
 
 	modifier.Register(TalentCheck, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnAfterAttack: func(mod *modifier.Instance, e event.AttackEndEvent) {
+			OnAfterAttack: func(mod *modifier.Instance, e event.AttackEnd) {
 				if len(e.Targets) == 0 {
 					return
 				}

--- a/internal/character/silverwolf/trace.go
+++ b/internal/character/silverwolf/trace.go
@@ -10,7 +10,7 @@ func (c *char) initTraces() {
 	// 	with Weakness Break, Silver Wolf has a 65% base chance of implanting a
 	// 	random Bug in the enemy.
 	if c.info.Traces["1006101"] {
-		c.engine.Events().StanceBreak.Subscribe(func(e event.StanceBreakEvent) {
+		c.engine.Events().StanceBreak.Subscribe(func(e event.StanceBreak) {
 			mod := newRandomBug(c.engine, e.Target, c.id)
 			mod.Chance = 0.65
 			c.engine.AddModifier(e.Target, mod)

--- a/internal/character/sushang/talent.go
+++ b/internal/character/sushang/talent.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 func (c *char) initTalent() {
-	c.engine.Events().StanceBreak.Subscribe(func(e event.StanceBreakEvent) {
+	c.engine.Events().StanceBreak.Subscribe(func(e event.StanceBreak) {
 		c.addTalentBuff()
 	})
 }

--- a/internal/character/sushang/trace.go
+++ b/internal/character/sushang/trace.go
@@ -79,7 +79,7 @@ func a2HPCheck(mod *modifier.Instance) {
 	}
 }
 
-func a4OnBeforeHitAll(mod *modifier.Instance, e event.HitStartEvent) {
+func a4OnBeforeHitAll(mod *modifier.Instance, e event.HitStart) {
 	stacks := mod.State().(float64)
 	e.Hit.Attacker.AddProperty(prop.AllDamagePercent, stacks*0.025)
 }

--- a/internal/character/sushang/trace.go
+++ b/internal/character/sushang/trace.go
@@ -30,7 +30,7 @@ func init() {
 	modifier.Register(A2Check, modifier.Config{
 		Listeners: modifier.Listeners{
 			OnAdd: a2HPCheck,
-			OnHPChange: func(mod *modifier.Instance, e event.HPChangeEvent) {
+			OnHPChange: func(mod *modifier.Instance, e event.HPChange) {
 				a2HPCheck(mod)
 			},
 		},

--- a/internal/global/common/entangle.go
+++ b/internal/global/common/entangle.go
@@ -51,7 +51,7 @@ func entangleAdd(mod *modifier.Instance) {
 	mod.Engine().ModifyGaugeNormalized(mod.Owner(), state.DelayRatio)
 }
 
-func entangleAfterAttack(mod *modifier.Instance, e event.AttackEndEvent) {
+func entangleAfterAttack(mod *modifier.Instance, e event.AttackEnd) {
 	state := mod.State().(EntangleState)
 
 	// increase count by 1 for each attack within this state

--- a/internal/global/global.go
+++ b/internal/global/global.go
@@ -14,7 +14,7 @@ func init() {
 
 // When a target dies, give 10 energy to the killer (that can be scaled with ERR)
 func EnergyOnDeath(engine engine.Engine) error {
-	engine.Events().TargetDeath.Subscribe(func(event event.TargetDeathEvent) {
+	engine.Events().TargetDeath.Subscribe(func(event event.TargetDeath) {
 		engine.ModifyEnergy(event.Killer, 10.0)
 	})
 	return nil

--- a/internal/lightcone/abundance/cornucopia/cornucopia.go
+++ b/internal/lightcone/abundance/cornucopia/cornucopia.go
@@ -47,7 +47,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 }
 
 // add buff only on skill and ult actions
-func buffHealsOnSkillUlt(mod *modifier.Instance, e event.ActionEvent) {
+func buffHealsOnSkillUlt(mod *modifier.Instance, e event.ActionStartEvent) {
 	healAmt := mod.State().(float64)
 	switch e.AttackType {
 	case model.AttackType_SKILL, model.AttackType_ULT:

--- a/internal/lightcone/abundance/cornucopia/cornucopia.go
+++ b/internal/lightcone/abundance/cornucopia/cornucopia.go
@@ -60,6 +60,6 @@ func buffHealsOnSkillUlt(mod *modifier.Instance, e event.ActionStartEvent) {
 }
 
 // remove buff after each "action"
-func removeHealBuff(mod *modifier.Instance, e event.ActionEvent) {
+func removeHealBuff(mod *modifier.Instance, e event.ActionEndEvent) {
 	mod.Engine().RemoveModifier(mod.Owner(), CornucopiaBuff)
 }

--- a/internal/lightcone/abundance/cornucopia/cornucopia.go
+++ b/internal/lightcone/abundance/cornucopia/cornucopia.go
@@ -47,7 +47,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 }
 
 // add buff only on skill and ult actions
-func buffHealsOnSkillUlt(mod *modifier.Instance, e event.ActionStartEvent) {
+func buffHealsOnSkillUlt(mod *modifier.Instance, e event.ActionStart) {
 	healAmt := mod.State().(float64)
 	switch e.AttackType {
 	case model.AttackType_SKILL, model.AttackType_ULT:
@@ -60,6 +60,6 @@ func buffHealsOnSkillUlt(mod *modifier.Instance, e event.ActionStartEvent) {
 }
 
 // remove buff after each "action"
-func removeHealBuff(mod *modifier.Instance, e event.ActionEndEvent) {
+func removeHealBuff(mod *modifier.Instance, e event.ActionEnd) {
 	mod.Engine().RemoveModifier(mod.Owner(), CornucopiaBuff)
 }

--- a/internal/lightcone/abundance/finefruit/finefruit.go
+++ b/internal/lightcone/abundance/finefruit/finefruit.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
-	engine.Events().BattleStart.Subscribe(func(event event.BattleStartEvent) {
+	engine.Events().BattleStart.Subscribe(func(event event.BattleStart) {
 		for char := range event.CharInfo {
 			engine.ModifyEnergy(char, 4.5+1.5*float64(lc.Imposition))
 		}

--- a/internal/lightcone/abundance/multiplication/multiplication.go
+++ b/internal/lightcone/abundance/multiplication/multiplication.go
@@ -22,7 +22,7 @@ func init() {
 
 	modifier.Register(Multiplication, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnBeforeAction: func(mod *modifier.Instance, e event.ActionStartEvent) {
+			OnBeforeAction: func(mod *modifier.Instance, e event.ActionStart) {
 				imposition := mod.State().(int)
 				if e.AttackType == model.AttackType_NORMAL {
 					mod.Engine().ModifyCurrentGaugeCost(-0.1 - float64(imposition)*0.02)

--- a/internal/lightcone/abundance/multiplication/multiplication.go
+++ b/internal/lightcone/abundance/multiplication/multiplication.go
@@ -22,7 +22,7 @@ func init() {
 
 	modifier.Register(Multiplication, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnBeforeAction: func(mod *modifier.Instance, e event.ActionEvent) {
+			OnBeforeAction: func(mod *modifier.Instance, e event.ActionStartEvent) {
 				imposition := mod.State().(int)
 				if e.AttackType == model.AttackType_NORMAL {
 					mod.Engine().ModifyCurrentGaugeCost(-0.1 - float64(imposition)*0.02)

--- a/internal/lightcone/abundance/postopconversation/postopconversation.go
+++ b/internal/lightcone/abundance/postopconversation/postopconversation.go
@@ -63,6 +63,6 @@ func buffHealsOnUlt(mod *modifier.Instance, e event.ActionStartEvent) {
 }
 
 // remove buff after each "action"
-func removeHealBuff(mod *modifier.Instance, e event.ActionEvent) {
+func removeHealBuff(mod *modifier.Instance, e event.ActionEndEvent) {
 	mod.Engine().RemoveModifier(mod.Owner(), PostOpHealBuff)
 }

--- a/internal/lightcone/abundance/postopconversation/postopconversation.go
+++ b/internal/lightcone/abundance/postopconversation/postopconversation.go
@@ -49,7 +49,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func buffHealsOnUlt(mod *modifier.Instance, e event.ActionStartEvent) {
+func buffHealsOnUlt(mod *modifier.Instance, e event.ActionStart) {
 	amt := mod.State().(float64)
 	// NOTE : DM said onbeforeheal(unlike cornucopia which uses OnBeforeAction)
 	// Once OnBeforeDealHeal has AttackType prop, need to change this.
@@ -63,6 +63,6 @@ func buffHealsOnUlt(mod *modifier.Instance, e event.ActionStartEvent) {
 }
 
 // remove buff after each "action"
-func removeHealBuff(mod *modifier.Instance, e event.ActionEndEvent) {
+func removeHealBuff(mod *modifier.Instance, e event.ActionEnd) {
 	mod.Engine().RemoveModifier(mod.Owner(), PostOpHealBuff)
 }

--- a/internal/lightcone/abundance/postopconversation/postopconversation.go
+++ b/internal/lightcone/abundance/postopconversation/postopconversation.go
@@ -49,7 +49,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func buffHealsOnUlt(mod *modifier.Instance, e event.ActionEvent) {
+func buffHealsOnUlt(mod *modifier.Instance, e event.ActionStartEvent) {
 	amt := mod.State().(float64)
 	// NOTE : DM said onbeforeheal(unlike cornucopia which uses OnBeforeAction)
 	// Once OnBeforeDealHeal has AttackType prop, need to change this.

--- a/internal/lightcone/abundance/sharedfeeling/sharedfeeling.go
+++ b/internal/lightcone/abundance/sharedfeeling/sharedfeeling.go
@@ -43,7 +43,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func giveTeamEnergy(mod *modifier.Instance, e event.ActionEvent) {
+func giveTeamEnergy(mod *modifier.Instance, e event.ActionEndEvent) {
 	amt := mod.State().(float64)
 	if e.AttackType == model.AttackType_SKILL {
 		// apply team energy top up.

--- a/internal/lightcone/abundance/sharedfeeling/sharedfeeling.go
+++ b/internal/lightcone/abundance/sharedfeeling/sharedfeeling.go
@@ -43,7 +43,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func giveTeamEnergy(mod *modifier.Instance, e event.ActionEndEvent) {
+func giveTeamEnergy(mod *modifier.Instance, e event.ActionEnd) {
 	amt := mod.State().(float64)
 	if e.AttackType == model.AttackType_SKILL {
 		// apply team energy top up.

--- a/internal/lightcone/abundance/warmthshortenscoldnights/warmthshortenscoldnights.go
+++ b/internal/lightcone/abundance/warmthshortenscoldnights/warmthshortenscoldnights.go
@@ -43,7 +43,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 }
 
 // if basic atk/skill, heal the whole team by x%
-func healTeamOnBasicOrSkill(mod *modifier.Instance, e event.ActionEvent) {
+func healTeamOnBasicOrSkill(mod *modifier.Instance, e event.ActionEndEvent) {
 	amt := mod.State().(float64)
 	switch e.AttackType {
 	case model.AttackType_NORMAL, model.AttackType_SKILL:

--- a/internal/lightcone/abundance/warmthshortenscoldnights/warmthshortenscoldnights.go
+++ b/internal/lightcone/abundance/warmthshortenscoldnights/warmthshortenscoldnights.go
@@ -43,7 +43,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 }
 
 // if basic atk/skill, heal the whole team by x%
-func healTeamOnBasicOrSkill(mod *modifier.Instance, e event.ActionEndEvent) {
+func healTeamOnBasicOrSkill(mod *modifier.Instance, e event.ActionEnd) {
 	amt := mod.State().(float64)
 	switch e.AttackType {
 	case model.AttackType_NORMAL, model.AttackType_SKILL:

--- a/internal/lightcone/destruction/asecretvow/asecretvow.go
+++ b/internal/lightcone/destruction/asecretvow/asecretvow.go
@@ -44,7 +44,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 }
 
 // If the enemy hp ratio is greater or equal than the attackers hp ratio, add dmg%
-func onBeforeHitAll(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeHitAll(mod *modifier.Instance, e event.HitStart) {
 	if e.Hit.Attacker.CurrentHPRatio() <= e.Hit.Defender.CurrentHPRatio() {
 		e.Hit.Attacker.AddProperty(prop.AllDamagePercent, mod.State().(float64))
 	}

--- a/internal/lightcone/destruction/collapsingsky/collapsingsky.go
+++ b/internal/lightcone/destruction/collapsingsky/collapsingsky.go
@@ -39,7 +39,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func onBeforeHit(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeHit(mod *modifier.Instance, e event.HitStart) {
 	dmgBonus := mod.State().(float64)
 
 	if e.Hit.AttackType == model.AttackType_NORMAL || e.Hit.AttackType == model.AttackType_SKILL {

--- a/internal/lightcone/destruction/mutualdemise/mutualdemise.go
+++ b/internal/lightcone/destruction/mutualdemise/mutualdemise.go
@@ -27,7 +27,7 @@ func init() {
 	modifier.Register(MutualDemiseCheck, modifier.Config{
 		Listeners: modifier.Listeners{
 			OnAdd: adjustCritRate,
-			OnHPChange: func(mod *modifier.Instance, e event.HPChangeEvent) {
+			OnHPChange: func(mod *modifier.Instance, e event.HPChange) {
 				adjustCritRate(mod)
 			},
 		},

--- a/internal/lightcone/destruction/onthefallofanaeon/onthefallofanaeon.go
+++ b/internal/lightcone/destruction/onthefallofanaeon/onthefallofanaeon.go
@@ -68,7 +68,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func onBeforeAttack(mod *modifier.Instance, e event.AttackStartEvent) {
+func onBeforeAttack(mod *modifier.Instance, e event.AttackStart) {
 	mod.Engine().AddModifier(mod.Owner(), info.Modifier{
 		Name:   BuffAtk,
 		Source: mod.Owner(),

--- a/internal/lightcone/destruction/shatteredhome/shatteredhome.go
+++ b/internal/lightcone/destruction/shatteredhome/shatteredhome.go
@@ -40,7 +40,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func onBeforeHitAll(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeHitAll(mod *modifier.Instance, e event.HitStart) {
 	if e.Hit.Defender.CurrentHPRatio() > 0.5 {
 		e.Hit.Attacker.AddProperty(prop.AllDamagePercent, mod.State().(float64))
 	}

--- a/internal/lightcone/destruction/somethingirreplaceable/somethingirreplaceable.go
+++ b/internal/lightcone/destruction/somethingirreplaceable/somethingirreplaceable.go
@@ -64,7 +64,7 @@ func onTriggerDeath(mod *modifier.Instance, target key.TargetID) {
 	conditions(mod)
 }
 
-func onAfterBeingAttacked(mod *modifier.Instance, e event.AttackEndEvent) {
+func onAfterBeingAttacked(mod *modifier.Instance, e event.AttackEnd) {
 	conditions(mod)
 }
 

--- a/internal/lightcone/destruction/themoleswelcomeyou/themoleswelcomeyou.go
+++ b/internal/lightcone/destruction/themoleswelcomeyou/themoleswelcomeyou.go
@@ -60,7 +60,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 }
 
 // after an attack, add 1 stack iff new attack type
-func onAfterAttack(mod *modifier.Instance, e event.AttackEndEvent) {
+func onAfterAttack(mod *modifier.Instance, e event.AttackEnd) {
 	state := mod.State().(checkState)
 
 	// must be normal, skill, or ult

--- a/internal/lightcone/erudition/beforedawn/beforedawn.go
+++ b/internal/lightcone/erudition/beforedawn/beforedawn.go
@@ -85,7 +85,7 @@ func onAfterAttack(mod *modifier.Instance, e event.AttackEndEvent) {
 }
 
 // AfterAction if its ult or skill add the SomnusCorpusMod
-func onAfterAction(mod *modifier.Instance, e event.ActionEndEvent) {
+func onAfterAction(mod *modifier.Instance, e event.ActionEnd) {
 	if e.AttackType == model.AttackType_ULT ||
 		e.AttackType == model.AttackType_SKILL {
 		amt := mod.State().(float64)

--- a/internal/lightcone/erudition/beforedawn/beforedawn.go
+++ b/internal/lightcone/erudition/beforedawn/beforedawn.go
@@ -60,7 +60,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 }
 
 // BeforeHit if its ult or skill add the dmg% to that hit
-func onBeforeHit(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeHit(mod *modifier.Instance, e event.HitStart) {
 	if e.Hit.AttackType == model.AttackType_ULT ||
 		e.Hit.AttackType == model.AttackType_SKILL {
 		e.Hit.Attacker.AddProperty(prop.AllDamagePercent, 0.15+0.03*mod.State().(float64))
@@ -68,7 +68,7 @@ func onBeforeHit(mod *modifier.Instance, e event.HitStartEvent) {
 }
 
 // Beforehit if its follow and it has the SomnusCorpusMod add the dmg% to that hit and change used to true
-func onBeforeHitSomnus(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeHitSomnus(mod *modifier.Instance, e event.HitStart) {
 	state := mod.State().(*somnusState)
 	if e.Hit.AttackType == model.AttackType_INSERT {
 		e.Hit.Attacker.AddProperty(prop.AllDamagePercent, state.amt)
@@ -77,7 +77,7 @@ func onBeforeHitSomnus(mod *modifier.Instance, e event.HitStartEvent) {
 }
 
 // after attack if SomnusCorpMod is used, remove self.
-func onAfterAttack(mod *modifier.Instance, e event.AttackEndEvent) {
+func onAfterAttack(mod *modifier.Instance, e event.AttackEnd) {
 	state := mod.State().(*somnusState)
 	if state.used {
 		mod.RemoveSelf()

--- a/internal/lightcone/erudition/beforedawn/beforedawn.go
+++ b/internal/lightcone/erudition/beforedawn/beforedawn.go
@@ -85,7 +85,7 @@ func onAfterAttack(mod *modifier.Instance, e event.AttackEndEvent) {
 }
 
 // AfterAction if its ult or skill add the SomnusCorpusMod
-func onAfterAction(mod *modifier.Instance, e event.ActionEvent) {
+func onAfterAction(mod *modifier.Instance, e event.ActionEndEvent) {
 	if e.AttackType == model.AttackType_ULT ||
 		e.AttackType == model.AttackType_SKILL {
 		amt := mod.State().(float64)

--- a/internal/lightcone/erudition/databank/databank.go
+++ b/internal/lightcone/erudition/databank/databank.go
@@ -38,7 +38,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func onBeforeHit(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeHit(mod *modifier.Instance, e event.HitStart) {
 	if e.Hit.AttackType == model.AttackType_ULT {
 		e.Hit.Attacker.AddProperty(prop.AllDamagePercent, mod.State().(float64))
 	}

--- a/internal/lightcone/erudition/passkey/passkey.go
+++ b/internal/lightcone/erudition/passkey/passkey.go
@@ -39,7 +39,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	}
 
 	// At the end of every turn, add this modifier (no-op if already exists)
-	engine.Events().TurnEnd.Subscribe(func(event event.TurnEndEvent) {
+	engine.Events().TurnEnd.Subscribe(func(event event.TurnEnd) {
 		engine.AddModifier(owner, mod)
 	})
 
@@ -48,7 +48,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 }
 
 // after giving energy, remove this modifier so it cannot do it again
-func onAfterAction(mod *modifier.Instance, e event.ActionEndEvent) {
+func onAfterAction(mod *modifier.Instance, e event.ActionEnd) {
 	mod.Engine().ModifyEnergy(mod.Owner(), mod.State().(float64))
 	mod.RemoveSelf()
 }

--- a/internal/lightcone/erudition/passkey/passkey.go
+++ b/internal/lightcone/erudition/passkey/passkey.go
@@ -48,7 +48,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 }
 
 // after giving energy, remove this modifier so it cannot do it again
-func onAfterAction(mod *modifier.Instance, e event.ActionEvent) {
+func onAfterAction(mod *modifier.Instance, e event.ActionEndEvent) {
 	mod.Engine().ModifyEnergy(mod.Owner(), mod.State().(float64))
 	mod.RemoveSelf()
 }

--- a/internal/lightcone/harmony/chorus/chorus.go
+++ b/internal/lightcone/harmony/chorus/chorus.go
@@ -48,7 +48,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 		Stats:  info.PropMap{prop.ATKPercent: 0.07 + 0.01*float64(lc.Imposition)},
 	}
 
-	engine.Events().BattleStart.Subscribe(func(event event.BattleStartEvent) {
+	engine.Events().BattleStart.Subscribe(func(event event.BattleStart) {
 		for char := range event.CharInfo {
 			engine.AddModifier(char, mod)
 		}

--- a/internal/lightcone/harmony/meshingcogs/meshingcogs.go
+++ b/internal/lightcone/harmony/meshingcogs/meshingcogs.go
@@ -53,7 +53,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 		State:  &state,
 	})
 
-	engine.Events().TurnEnd.Subscribe(func(e event.TurnEndEvent) {
+	engine.Events().TurnEnd.Subscribe(func(e event.TurnEnd) {
 		state.charged = true
 	})
 }

--- a/internal/lightcone/harmony/meshingcogs/meshingcogs.go
+++ b/internal/lightcone/harmony/meshingcogs/meshingcogs.go
@@ -33,7 +33,7 @@ func init() {
 	})
 }
 
-func tryEnergyRegen(mod *modifier.Instance, _ event.AttackEndEvent) {
+func tryEnergyRegen(mod *modifier.Instance, _ event.AttackEnd) {
 	state := mod.State().(*cogsState)
 	if !state.charged {
 		return

--- a/internal/lightcone/hunt/cruisinginthestellarsea/cruisinginthestellarsea.go
+++ b/internal/lightcone/hunt/cruisinginthestellarsea/cruisinginthestellarsea.go
@@ -57,7 +57,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func onBeforeHitAll(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeHitAll(mod *modifier.Instance, e event.HitStart) {
 	if e.Hit.Defender.CurrentHPRatio() <= 0.5 {
 		e.Hit.Attacker.AddProperty(prop.CritChance, mod.State().(Amts).cr)
 	}

--- a/internal/lightcone/hunt/inthenight/inthenight.go
+++ b/internal/lightcone/hunt/inthenight/inthenight.go
@@ -54,7 +54,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func onBeforeHit(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeHit(mod *modifier.Instance, e event.HitStart) {
 	spd := e.Hit.Attacker.SPD()
 
 	if spd >= 110 {

--- a/internal/lightcone/hunt/onlysilenceremains/onlysilenceremains.go
+++ b/internal/lightcone/hunt/onlysilenceremains/onlysilenceremains.go
@@ -35,7 +35,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	atkAmt := 0.12 + 0.04*float64(lc.Imposition)
 	crAmt := 0.09 + 0.03*float64(lc.Imposition)
 
-	engine.Events().EnemyAdded.Subscribe(func(e event.EnemyAddedEvent) {
+	engine.Events().EnemyAdded.Subscribe(func(e event.EnemyAdded) {
 		updateCRBuff(engine, owner, crAmt)
 	})
 

--- a/internal/lightcone/hunt/onlysilenceremains/onlysilenceremains.go
+++ b/internal/lightcone/hunt/onlysilenceremains/onlysilenceremains.go
@@ -39,7 +39,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 		updateCRBuff(engine, owner, crAmt)
 	})
 
-	engine.Events().TargetDeath.Subscribe(func(e event.TargetDeathEvent) {
+	engine.Events().TargetDeath.Subscribe(func(e event.TargetDeath) {
 		updateCRBuff(engine, owner, crAmt)
 	})
 

--- a/internal/lightcone/hunt/returntodarkness/returntodarkness.go
+++ b/internal/lightcone/hunt/returntodarkness/returntodarkness.go
@@ -56,7 +56,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func onAfterHitAll(mod *modifier.Instance, e event.HitEndEvent) {
+func onAfterHitAll(mod *modifier.Instance, e event.HitEnd) {
 	state := mod.State().(*State)
 
 	if e.IsCrit && !state.wasTriggered && rand.Float64() < state.chance {
@@ -69,6 +69,6 @@ func onAfterHitAll(mod *modifier.Instance, e event.HitEndEvent) {
 	}
 }
 
-func onAfterAttack(mod *modifier.Instance, e event.AttackEndEvent) {
+func onAfterAttack(mod *modifier.Instance, e event.AttackEnd) {
 	mod.State().(*State).wasTriggered = false
 }

--- a/internal/lightcone/hunt/riverflowsinspring/riverflowsinspring.go
+++ b/internal/lightcone/hunt/riverflowsinspring/riverflowsinspring.go
@@ -76,7 +76,7 @@ func onPhase2(mod *modifier.Instance) {
 	})
 }
 
-func onAfterBeingHitAll(mod *modifier.Instance, e event.HitEndEvent) {
+func onAfterBeingHitAll(mod *modifier.Instance, e event.HitEnd) {
 	if e.HPDamage > 0 {
 		mod.Engine().RemoveModifier(mod.Owner(), RiverFlowsinSpringBuff)
 	}

--- a/internal/lightcone/hunt/sleeplikethedead/sleeplikethedead.go
+++ b/internal/lightcone/hunt/sleeplikethedead/sleeplikethedead.go
@@ -57,7 +57,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func onAfterHit(mod *modifier.Instance, e event.HitEndEvent) {
+func onAfterHit(mod *modifier.Instance, e event.HitEnd) {
 	if !e.IsCrit && !mod.Engine().HasModifier(mod.Owner(), Cooldown) {
 		if e.AttackType == model.AttackType_NORMAL || e.AttackType == model.AttackType_SKILL {
 			mod.Engine().AddModifier(mod.Owner(), info.Modifier{

--- a/internal/lightcone/hunt/subscribeformore/subscribeformore.go
+++ b/internal/lightcone/hunt/subscribeformore/subscribeformore.go
@@ -41,7 +41,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func onBeforeHit(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeHit(mod *modifier.Instance, e event.HitStart) {
 	if e.Hit.AttackType == model.AttackType_NORMAL || e.Hit.AttackType == model.AttackType_SKILL {
 		amt := mod.State().(float64)
 		if e.Hit.Attacker.Energy() == e.Hit.Attacker.MaxEnergy() {

--- a/internal/lightcone/hunt/swordplay/swordplay.go
+++ b/internal/lightcone/hunt/swordplay/swordplay.go
@@ -58,7 +58,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func onBeforeHit(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeHit(mod *modifier.Instance, e event.HitStart) {
 	if !hasModifierFromSource(mod.Engine(), e.Defender, mod.Owner(), Target) {
 		if mod.Engine().HasModifier(mod.Owner(), Buff) {
 			stacks := mod.Engine().GetModifiers(mod.Owner(), Buff)[0].Count
@@ -86,7 +86,7 @@ func hasModifierFromSource(engine engine.Engine, target, source key.TargetID, ke
 	return false
 }
 
-func onAfterHit(mod *modifier.Instance, e event.HitEndEvent) {
+func onAfterHit(mod *modifier.Instance, e event.HitEnd) {
 	if mod.Engine().HasModifier(mod.Owner(), Buff) {
 		stacks := mod.Engine().GetModifiers(mod.Owner(), Buff)[0].Count
 		if stacks == 5 {

--- a/internal/lightcone/nihility/fermata/fermata.go
+++ b/internal/lightcone/nihility/fermata/fermata.go
@@ -49,7 +49,7 @@ var triggerFlags = []model.BehaviorFlag{
 	model.BehaviorFlag_STAT_DOT_POISON,
 }
 
-func onBeforeHitAll(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeHitAll(mod *modifier.Instance, e event.HitStart) {
 	amt := mod.State().(float64)
 
 	if mod.Engine().HasBehaviorFlag(e.Defender, triggerFlags...) {

--- a/internal/lightcone/nihility/goodnightandsleepwell/goodnightandsleepwell.go
+++ b/internal/lightcone/nihility/goodnightandsleepwell/goodnightandsleepwell.go
@@ -42,7 +42,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func onBeforeHitAll(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeHitAll(mod *modifier.Instance, e event.HitStart) {
 	debuffCount := float64(e.Hit.Defender.StatusCount(model.StatusType_STATUS_DEBUFF))
 	if debuffCount > 3 {
 		debuffCount = 3

--- a/internal/lightcone/preservation/amber/amber.go
+++ b/internal/lightcone/preservation/amber/amber.go
@@ -30,7 +30,7 @@ func init() {
 	modifier.Register(amber, modifier.Config{
 		Listeners: modifier.Listeners{
 			OnAdd: onLowerHalfHp,
-			OnHPChange: func(mod *modifier.Instance, e event.HPChangeEvent) {
+			OnHPChange: func(mod *modifier.Instance, e event.HPChange) {
 				onLowerHalfHp(mod)
 			},
 		},

--- a/internal/lightcone/preservation/dayoneofmynewlife/dayoneofmynewlife.go
+++ b/internal/lightcone/preservation/dayoneofmynewlife/dayoneofmynewlife.go
@@ -55,7 +55,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	// NOTE: fine to leave this as-is, but this may have to change in the
 	// future when adding support for multiple waves. `BattleStart` happens
 	// at the beginning of each wave
-	engine.Events().BattleStart.Subscribe(func(event event.BattleStartEvent) {
+	engine.Events().BattleStart.Subscribe(func(event event.BattleStart) {
 		for char := range event.CharInfo {
 			engine.AddModifier(char, mod)
 		}

--- a/internal/lightcone/preservation/defense/defense.go
+++ b/internal/lightcone/preservation/defense/defense.go
@@ -41,7 +41,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func onBeforeAction(mod *modifier.Instance, e event.ActionStartEvent) {
+func onBeforeAction(mod *modifier.Instance, e event.ActionStart) {
 	healAmt := mod.State().(float64)
 
 	if e.AttackType == model.AttackType_ULT {

--- a/internal/lightcone/preservation/defense/defense.go
+++ b/internal/lightcone/preservation/defense/defense.go
@@ -41,7 +41,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	})
 }
 
-func onBeforeAction(mod *modifier.Instance, e event.ActionEvent) {
+func onBeforeAction(mod *modifier.Instance, e event.ActionStartEvent) {
 	healAmt := mod.State().(float64)
 
 	if e.AttackType == model.AttackType_ULT {

--- a/internal/lightcone/preservation/momentofvictory/moment.go
+++ b/internal/lightcone/preservation/momentofvictory/moment.go
@@ -58,6 +58,6 @@ func onPhase2(mod *modifier.Instance) {
 }
 
 // after attack, double the DEF
-func onAfterBeingAttacked(mod *modifier.Instance, e event.AttackEndEvent) {
+func onAfterBeingAttacked(mod *modifier.Instance, e event.AttackEnd) {
 	mod.SetProperty(prop.DEFPercent, 2.0*mod.State().(float64))
 }

--- a/internal/lightcone/preservation/textureofmemories/textureofmemories.go
+++ b/internal/lightcone/preservation/textureofmemories/textureofmemories.go
@@ -69,7 +69,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 }
 
 // wearer has Shield before attacked
-func onBeforeBeingHitAll(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeBeingHitAll(mod *modifier.Instance, e event.HitStart) {
 	if mod.Engine().IsShielded(mod.Owner()) {
 		state := mod.State().(State)
 		e.Hit.Defender.AddProperty(prop.AllDamageReduce, state.dmgRes)
@@ -77,7 +77,7 @@ func onBeforeBeingHitAll(mod *modifier.Instance, e event.HitStartEvent) {
 }
 
 // wearer doesn't have Shield after attacked
-func onAfterBeingAttacked(mod *modifier.Instance, e event.AttackEndEvent) {
+func onAfterBeingAttacked(mod *modifier.Instance, e event.AttackEnd) {
 	isShielded := mod.Engine().IsShielded(mod.Owner())
 	isOnCd := mod.Engine().HasModifier(mod.Owner(), modcd)
 

--- a/internal/lightcone/preservation/thisisme/thisisme.go
+++ b/internal/lightcone/preservation/thisisme/thisisme.go
@@ -64,7 +64,7 @@ func onBeforeHit(mod *modifier.Instance, e event.HitStartEvent) {
 }
 
 // remove modifier so next ult deals ult dmg + only 1x bonus from this lc
-func onAfterAction(mod *modifier.Instance, e event.ActionEvent) {
+func onAfterAction(mod *modifier.Instance, e event.ActionEndEvent) {
 	state := mod.State().(State)
 	for k := range state.idMap {
 		delete(state.idMap, k)

--- a/internal/lightcone/preservation/thisisme/thisisme.go
+++ b/internal/lightcone/preservation/thisisme/thisisme.go
@@ -53,7 +53,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 }
 
 // increase ult damage
-func onBeforeHit(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeHit(mod *modifier.Instance, e event.HitStart) {
 	state := mod.State().(State)
 	_, hasID := state.idMap[e.Hit.Defender.ID()]
 

--- a/internal/lightcone/preservation/thisisme/thisisme.go
+++ b/internal/lightcone/preservation/thisisme/thisisme.go
@@ -64,7 +64,7 @@ func onBeforeHit(mod *modifier.Instance, e event.HitStartEvent) {
 }
 
 // remove modifier so next ult deals ult dmg + only 1x bonus from this lc
-func onAfterAction(mod *modifier.Instance, e event.ActionEndEvent) {
+func onAfterAction(mod *modifier.Instance, e event.ActionEnd) {
 	state := mod.State().(State)
 	for k := range state.idMap {
 		delete(state.idMap, k)

--- a/internal/lightcone/preservation/trendoftheuniversalmarket/trendoftheuniversalmarket.go
+++ b/internal/lightcone/preservation/trendoftheuniversalmarket/trendoftheuniversalmarket.go
@@ -56,7 +56,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 }
 
 // chance to DoT the attacker
-func onAfterBeingAttacked(mod *modifier.Instance, e event.AttackEndEvent) {
+func onAfterBeingAttacked(mod *modifier.Instance, e event.AttackEnd) {
 	state := mod.State().(State)
 
 	mod.Engine().AddModifier(e.Attacker, info.Modifier{

--- a/internal/lightcone/preservation/wearewildfire/wearewildfire.go
+++ b/internal/lightcone/preservation/wearewildfire/wearewildfire.go
@@ -48,7 +48,7 @@ func Create(engine engine.Engine, owner key.TargetID, lc info.LightCone) {
 	}
 
 	// TODO: recheck when multiple waves support is added
-	engine.Events().BattleStart.Subscribe(func(event event.BattleStartEvent) {
+	engine.Events().BattleStart.Subscribe(func(event event.BattleStart) {
 		for char := range event.CharInfo {
 			engine.AddModifier(char, dmgmod)
 		}

--- a/internal/relic/cavern/hunterofglacialforest/hunterofglacialforest.go
+++ b/internal/relic/cavern/hunterofglacialforest/hunterofglacialforest.go
@@ -50,7 +50,7 @@ func init() {
 	})
 }
 
-func onBeforeAction(mod *modifier.Instance, e event.ActionStartEvent) {
+func onBeforeAction(mod *modifier.Instance, e event.ActionStart) {
 	if e.AttackType == model.AttackType_ULT {
 		mod.Engine().AddModifier(mod.Owner(), info.Modifier{
 			Name:     buff,

--- a/internal/relic/cavern/hunterofglacialforest/hunterofglacialforest.go
+++ b/internal/relic/cavern/hunterofglacialforest/hunterofglacialforest.go
@@ -50,7 +50,7 @@ func init() {
 	})
 }
 
-func onBeforeAction(mod *modifier.Instance, e event.ActionEvent) {
+func onBeforeAction(mod *modifier.Instance, e event.ActionStartEvent) {
 	if e.AttackType == model.AttackType_ULT {
 		mod.Engine().AddModifier(mod.Owner(), info.Modifier{
 			Name:     buff,

--- a/internal/relic/cavern/musketeer/musketeer.go
+++ b/internal/relic/cavern/musketeer/musketeer.go
@@ -39,7 +39,7 @@ func init() {
 
 	modifier.Register(mod, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnBeforeHit: func(mod *modifier.Instance, e event.HitStartEvent) {
+			OnBeforeHit: func(mod *modifier.Instance, e event.HitStart) {
 				if e.Hit.AttackType == model.AttackType_NORMAL {
 					e.Hit.Attacker.AddProperty(prop.AllDamagePercent, 0.1)
 				}

--- a/internal/relic/planar/salsotto/salsotto.go
+++ b/internal/relic/planar/salsotto/salsotto.go
@@ -42,7 +42,7 @@ func init() {
 	})
 }
 
-func onBeforeHit(mod *modifier.Instance, e event.HitStartEvent) {
+func onBeforeHit(mod *modifier.Instance, e event.HitStart) {
 	stats := mod.OwnerStats()
 	if stats.CritChance() >= 0.50 {
 		if e.Hit.AttackType == model.AttackType_ULT || e.Hit.AttackType == model.AttackType_INSERT {

--- a/internal/relic/planar/vonwacq/vonwacq.go
+++ b/internal/relic/planar/vonwacq/vonwacq.go
@@ -29,7 +29,7 @@ func init() {
 }
 
 func Create(engine engine.Engine, owner key.TargetID) {
-	engine.Events().BattleStart.Subscribe(func(e event.BattleStartEvent) {
+	engine.Events().BattleStart.Subscribe(func(e event.BattleStart) {
 		for _, char := range e.CharStats {
 			if char.ID() == owner && char.SPD() >= 120 {
 				engine.ModifyGaugeNormalized(char.ID(), -0.4)

--- a/pkg/engine/attribute/event.go
+++ b/pkg/engine/attribute/event.go
@@ -11,7 +11,7 @@ func (s *Service) emitHPChangeEvents(
 		return nil
 	}
 
-	s.event.HPChange.Emit(event.HPChangeEvent{
+	s.event.HPChange.Emit(event.HPChange{
 		Target:             target,
 		OldHPRatio:         oldRatio,
 		NewHPRatio:         newRatio,
@@ -25,11 +25,11 @@ func (s *Service) emitHPChangeEvents(
 	}
 
 	// if event gets canceled, do not want to emit the death event
-	if s.event.LimboWaitHeal.Emit(event.LimboWaitHealEvent{Target: target}) {
+	if s.event.LimboWaitHeal.Emit(event.LimboWaitHeal{Target: target}) {
 		return nil
 	}
 
-	s.event.TargetDeath.Emit(event.TargetDeathEvent{
+	s.event.TargetDeath.Emit(event.TargetDeath{
 		Target: target,
 		Killer: source,
 	})
@@ -41,19 +41,19 @@ func (s *Service) emitStanceChange(target, source key.TargetID, prevS, newS floa
 		return nil
 	}
 
-	s.event.StanceChange.Emit(event.StanceChangeEvent{
+	s.event.StanceChange.Emit(event.StanceChange{
 		Target:    target,
 		OldStance: prevS,
 		NewStance: newS,
 	})
 
 	if newS == 0 {
-		s.event.StanceBreak.Emit(event.StanceBreakEvent{
+		s.event.StanceBreak.Emit(event.StanceBreak{
 			Target: target,
 			Source: source,
 		})
 	} else if prevS == 0 {
-		s.event.StanceReset.Emit(event.StanceResetEvent{
+		s.event.StanceReset.Emit(event.StanceReset{
 			Target: target,
 		})
 	}
@@ -62,7 +62,7 @@ func (s *Service) emitStanceChange(target, source key.TargetID, prevS, newS floa
 
 func (s *Service) emitEnergyChange(target key.TargetID, prevE, newE float64) error {
 	if prevE != newE {
-		s.event.EnergyChange.Emit(event.EnergyChangeEvent{
+		s.event.EnergyChange.Emit(event.EnergyChange{
 			Target:    target,
 			OldEnergy: prevE,
 			NewEnergy: newE,

--- a/pkg/engine/attribute/event.go
+++ b/pkg/engine/attribute/event.go
@@ -53,7 +53,7 @@ func (s *Service) emitStanceChange(target, source key.TargetID, prevS, newS floa
 			Source: source,
 		})
 	} else if prevS == 0 {
-		s.event.StanceBreakEnd.Emit(event.StanceBreakEndEvent{
+		s.event.StanceReset.Emit(event.StanceResetEvent{
 			Target: target,
 		})
 	}

--- a/pkg/engine/combat/attack.go
+++ b/pkg/engine/combat/attack.go
@@ -20,7 +20,7 @@ func (mgr *Manager) Attack(atk info.Attack) {
 			damageType: atk.DamageType,
 		}
 
-		mgr.event.AttackStart.Emit(event.AttackStartEvent{
+		mgr.event.AttackStart.Emit(event.AttackStart{
 			Attacker:   atk.Source,
 			AttackType: atk.AttackType,
 			Targets:    atk.Targets,
@@ -36,7 +36,7 @@ func (mgr *Manager) Attack(atk info.Attack) {
 func (mgr *Manager) EndAttack() {
 	if mgr.isInAttack {
 		mgr.isInAttack = false
-		mgr.event.AttackEnd.Emit(event.AttackEndEvent{
+		mgr.event.AttackEnd.Emit(event.AttackEnd{
 			Attacker:   mgr.attackInfo.attacker,
 			Targets:    mgr.attackInfo.targets,
 			AttackType: mgr.attackInfo.attackType,

--- a/pkg/engine/combat/heal.go
+++ b/pkg/engine/combat/heal.go
@@ -12,7 +12,7 @@ func (mgr *Manager) Heal(heal info.Heal) {
 			baseHeal[k] = v
 		}
 
-		e := &event.HealStartEvent{
+		e := &event.HealStart{
 			Target:      mgr.attr.Stats(t),
 			Healer:      mgr.attr.Stats(heal.Source),
 			BaseHeal:    baseHeal,
@@ -24,7 +24,7 @@ func (mgr *Manager) Heal(heal info.Heal) {
 		// TODO: Perform Heal. Use the data in the event to perform the heal
 		// TOOD: call ModifyHP to add the new HP to the healed target
 
-		mgr.event.HealEnd.Emit(event.HealEndEvent{
+		mgr.event.HealEnd.Emit(event.HealEnd{
 			Target:             t,
 			Healer:             heal.Source,
 			HealAmount:         0, // TODO:

--- a/pkg/engine/combat/hit.go
+++ b/pkg/engine/combat/hit.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (mgr *Manager) performHit(hit *info.Hit) {
-	mgr.event.HitStart.Emit(event.HitStartEvent{
+	mgr.event.HitStart.Emit(event.HitStart{
 		Attacker: hit.Attacker.ID(),
 		Defender: hit.Defender.ID(),
 		Hit:      hit,
@@ -27,7 +27,7 @@ func (mgr *Manager) performHit(hit *info.Hit) {
 	// * dots & element damage do not crit (unknown if also ByPureDamage?)
 	// * ByPureDamage = true means a "simplified" damage function (the break damage equation)
 
-	mgr.event.HitEnd.Emit(event.HitEndEvent{
+	mgr.event.HitEnd.Emit(event.HitEnd{
 		Attacker:         hit.Attacker.ID(),
 		Defender:         hit.Defender.ID(),
 		AttackType:       hit.AttackType,

--- a/pkg/engine/event/attribute.go
+++ b/pkg/engine/event/attribute.go
@@ -18,7 +18,7 @@ type HPChangeEvent struct {
 type LimboWaitHealEventHandler = handler.CancelableEventHandler[LimboWaitHealEvent]
 type LimboWaitHealEvent struct {
 	Target      key.TargetID
-	IsCancelled bool
+	IsCancelled bool `exhaustruct:"optional"`
 }
 
 func (e LimboWaitHealEvent) Cancelled() handler.CancellableEvent {

--- a/pkg/engine/event/attribute.go
+++ b/pkg/engine/event/attribute.go
@@ -52,8 +52,8 @@ type StanceBreakEvent struct {
 	Source key.TargetID
 }
 
-type StanceBreakEndEventHandler = handler.EventHandler[StanceBreakEndEvent]
-type StanceBreakEndEvent struct {
+type StanceResetEventHandler = handler.EventHandler[StanceResetEvent]
+type StanceResetEvent struct {
 	Target key.TargetID
 }
 

--- a/pkg/engine/event/attribute.go
+++ b/pkg/engine/event/attribute.go
@@ -5,8 +5,8 @@ import (
 	"github.com/simimpact/srsim/pkg/key"
 )
 
-type HPChangeEventHandler = handler.EventHandler[HPChangeEvent]
-type HPChangeEvent struct {
+type HPChangeEventHandler = handler.EventHandler[HPChange]
+type HPChange struct {
 	Target             key.TargetID
 	OldHPRatio         float64
 	NewHPRatio         float64
@@ -15,50 +15,50 @@ type HPChangeEvent struct {
 	IsHPChangeByDamage bool
 }
 
-type LimboWaitHealEventHandler = handler.CancelableEventHandler[LimboWaitHealEvent]
-type LimboWaitHealEvent struct {
+type LimboWaitHealEventHandler = handler.CancelableEventHandler[LimboWaitHeal]
+type LimboWaitHeal struct {
 	Target      key.TargetID
 	IsCancelled bool `exhaustruct:"optional"`
 }
 
-func (e LimboWaitHealEvent) Cancelled() handler.CancellableEvent {
+func (e LimboWaitHeal) Cancelled() handler.CancellableEvent {
 	e.IsCancelled = true
 	return e
 }
 
-type TargetDeathEventHandler = handler.EventHandler[TargetDeathEvent]
-type TargetDeathEvent struct {
+type TargetDeathEventHandler = handler.EventHandler[TargetDeath]
+type TargetDeath struct {
 	Target key.TargetID
 	Killer key.TargetID
 }
 
-type EnergyChangeEventHandler = handler.EventHandler[EnergyChangeEvent]
-type EnergyChangeEvent struct {
+type EnergyChangeEventHandler = handler.EventHandler[EnergyChange]
+type EnergyChange struct {
 	Target    key.TargetID
 	OldEnergy float64
 	NewEnergy float64
 }
 
-type StanceChangeEventHandler = handler.EventHandler[StanceChangeEvent]
-type StanceChangeEvent struct {
+type StanceChangeEventHandler = handler.EventHandler[StanceChange]
+type StanceChange struct {
 	Target    key.TargetID
 	OldStance float64
 	NewStance float64
 }
 
-type StanceBreakEventHandler = handler.EventHandler[StanceBreakEvent]
-type StanceBreakEvent struct {
+type StanceBreakEventHandler = handler.EventHandler[StanceBreak]
+type StanceBreak struct {
 	Target key.TargetID
 	Source key.TargetID
 }
 
-type StanceResetEventHandler = handler.EventHandler[StanceResetEvent]
-type StanceResetEvent struct {
+type StanceResetEventHandler = handler.EventHandler[StanceReset]
+type StanceReset struct {
 	Target key.TargetID
 }
 
-type SPChangeEventHandler = handler.EventHandler[SPChangeEvent]
-type SPChangeEvent struct {
+type SPChangeEventHandler = handler.EventHandler[SPChange]
+type SPChange struct {
 	OldSP int
 	NewSP int
 }

--- a/pkg/engine/event/character.go
+++ b/pkg/engine/event/character.go
@@ -6,8 +6,8 @@ import (
 	"github.com/simimpact/srsim/pkg/key"
 )
 
-type CharacterAddedEventHandler = handler.EventHandler[CharacterAddedEvent]
-type CharacterAddedEvent struct {
+type CharacterAddedEventHandler = handler.EventHandler[CharacterAdded]
+type CharacterAdded struct {
 	ID   key.TargetID
 	Info info.Character
 }

--- a/pkg/engine/event/combat.go
+++ b/pkg/engine/event/combat.go
@@ -7,31 +7,31 @@ import (
 	"github.com/simimpact/srsim/pkg/model"
 )
 
-type AttackStartEventHandler = handler.EventHandler[AttackStartEvent]
-type AttackStartEvent struct {
+type AttackStartEventHandler = handler.EventHandler[AttackStart]
+type AttackStart struct {
 	Attacker   key.TargetID
 	Targets    []key.TargetID
 	AttackType model.AttackType
 	DamageType model.DamageType
 }
 
-type AttackEndEventHandler = handler.EventHandler[AttackEndEvent]
-type AttackEndEvent struct {
+type AttackEndEventHandler = handler.EventHandler[AttackEnd]
+type AttackEnd struct {
 	Attacker   key.TargetID
 	Targets    []key.TargetID
 	AttackType model.AttackType
 	DamageType model.DamageType
 }
 
-type HitStartEventHandler = handler.EventHandler[HitStartEvent]
-type HitStartEvent struct {
+type HitStartEventHandler = handler.EventHandler[HitStart]
+type HitStart struct {
 	Attacker key.TargetID
 	Defender key.TargetID
 	Hit      *info.Hit
 }
 
-type HitEndEventHandler = handler.EventHandler[HitEndEvent]
-type HitEndEvent struct {
+type HitEndEventHandler = handler.EventHandler[HitEnd]
+type HitEnd struct {
 	Attacker         key.TargetID
 	Defender         key.TargetID
 	AttackType       model.AttackType
@@ -46,8 +46,8 @@ type HitEndEvent struct {
 	UseSnapshot      bool
 }
 
-type HealStartEventHandler = handler.MutableEventHandler[HealStartEvent]
-type HealStartEvent struct {
+type HealStartEventHandler = handler.MutableEventHandler[HealStart]
+type HealStart struct {
 	Target      *info.Stats
 	Healer      *info.Stats
 	BaseHeal    info.HealMap
@@ -55,8 +55,8 @@ type HealStartEvent struct {
 	UseSnapshot bool
 }
 
-type HealEndEventHandler = handler.EventHandler[HealEndEvent]
-type HealEndEvent struct {
+type HealEndEventHandler = handler.EventHandler[HealEnd]
+type HealEnd struct {
 	Target             key.TargetID
 	Healer             key.TargetID
 	HealAmount         float64

--- a/pkg/engine/event/enemy.go
+++ b/pkg/engine/event/enemy.go
@@ -6,8 +6,8 @@ import (
 	"github.com/simimpact/srsim/pkg/key"
 )
 
-type EnemyAddedEventHandler = handler.EventHandler[EnemyAddedEvent]
-type EnemyAddedEvent struct {
+type EnemyAddedEventHandler = handler.EventHandler[EnemyAdded]
+type EnemyAdded struct {
 	ID   key.TargetID
 	Info info.Enemy
 }

--- a/pkg/engine/event/event.go
+++ b/pkg/engine/event/event.go
@@ -7,8 +7,9 @@ import "github.com/simimpact/srsim/pkg/engine/event/handler"
 type System struct {
 	Initialize  InitializeEventHandler
 	BattleStart BattleStartEventHandler
-	TurnEnd     TurnEndEventHandler
 	Termination TerminationEventHandler
+	TurnStart   TurnStartEventHandler
+	TurnEnd     TurnEndEventHandler
 	ActionStart ActionStartEventHandler
 	ActionEnd   ActionEndEventHandler
 	InsertStart InsertStartEventHandler
@@ -34,17 +35,16 @@ type System struct {
 	ShieldRemoved ShieldRemovedEventHandler
 	ShieldChange  ShieldChangeEventHandler
 
-	HPChange       HPChangeEventHandler
-	LimboWaitHeal  LimboWaitHealEventHandler
-	TargetDeath    TargetDeathEventHandler
-	EnergyChange   EnergyChangeEventHandler
-	StanceChange   StanceChangeEventHandler
-	StanceBreak    StanceBreakEventHandler
-	StanceBreakEnd StanceBreakEndEventHandler
-	SPChange       SPChangeEventHandler
+	HPChange      HPChangeEventHandler
+	LimboWaitHeal LimboWaitHealEventHandler
+	TargetDeath   TargetDeathEventHandler
+	EnergyChange  EnergyChangeEventHandler
+	StanceChange  StanceChangeEventHandler
+	StanceBreak   StanceBreakEventHandler
+	StanceReset   StanceResetEventHandler
+	SPChange      SPChangeEventHandler
 
 	TurnTargetsAdded       TurnTargetsAddedEventHandler
-	TurnStart              TurnStartEventHandler
 	TurnReset              TurnResetEventHandler
 	GaugeChange            GaugeChangeEventHandler
 	CurrentGaugeCostChange CurrentGaugeCostChangeEventHandler

--- a/pkg/engine/event/event.go
+++ b/pkg/engine/event/event.go
@@ -11,8 +11,6 @@ type System struct {
 	Termination TerminationEventHandler
 	ActionStart ActionStartEventHandler
 	ActionEnd   ActionEndEventHandler
-	UltStart    UltStartEventHandler
-	UltEnd      UltEndEventHandler
 	InsertStart InsertStartEventHandler
 	InsertEnd   InsertEndEventHandler
 

--- a/pkg/engine/event/handler/cancel_test.go
+++ b/pkg/engine/event/handler/cancel_test.go
@@ -18,7 +18,7 @@ func (e testCancelEvent) Cancelled() CancellableEvent {
 
 func TestCancelableEmitNoSubscription(t *testing.T) {
 	var handler CancelableEventHandler[testCancelEvent]
-	assert.False(t, handler.Emit(testCancelEvent{}))
+	assert.False(t, handler.Emit(testCancelEvent{cancelled: false}))
 }
 
 func TestCancelableListeners(t *testing.T) {
@@ -42,6 +42,6 @@ func TestCancelableListeners(t *testing.T) {
 		return false
 	}, 0)
 
-	handler.Emit(testCancelEvent{})
+	handler.Emit(testCancelEvent{cancelled: false})
 	assert.Equal(t, 2, callCount)
 }

--- a/pkg/engine/event/modifier.go
+++ b/pkg/engine/event/modifier.go
@@ -6,15 +6,15 @@ import (
 	"github.com/simimpact/srsim/pkg/key"
 )
 
-type ModifierAddedEventHandler = handler.EventHandler[ModifierAddedEvent]
-type ModifierAddedEvent struct {
+type ModifierAddedEventHandler = handler.EventHandler[ModifierAdded]
+type ModifierAdded struct {
 	Target   key.TargetID
 	Modifier info.Modifier
 	Chance   float64
 }
 
-type ModifierResistedEventHandler = handler.EventHandler[ModifierResistedEvent]
-type ModifierResistedEvent struct {
+type ModifierResistedEventHandler = handler.EventHandler[ModifierResisted]
+type ModifierResisted struct {
 	Target     key.TargetID
 	Source     key.TargetID
 	Modifier   key.Modifier
@@ -25,22 +25,22 @@ type ModifierResistedEvent struct {
 	DebuffRES  float64
 }
 
-type ModifierRemovedEventHandler = handler.EventHandler[ModifierRemovedEvent]
-type ModifierRemovedEvent struct {
+type ModifierRemovedEventHandler = handler.EventHandler[ModifierRemoved]
+type ModifierRemoved struct {
 	Target   key.TargetID
 	Modifier info.Modifier
 }
 
-type ModifierExtendedDurationEventHandler = handler.EventHandler[ModifierExtendedDurationEvent]
-type ModifierExtendedDurationEvent struct {
+type ModifierExtendedDurationEventHandler = handler.EventHandler[ModifierExtendedDuration]
+type ModifierExtendedDuration struct {
 	Target   key.TargetID
 	Modifier info.Modifier
 	OldValue int
 	NewValue int
 }
 
-type ModifierExtendedCountEventHandler = handler.EventHandler[ModifierExtendedCountEvent]
-type ModifierExtendedCountEvent struct {
+type ModifierExtendedCountEventHandler = handler.EventHandler[ModifierExtendedCount]
+type ModifierExtendedCount struct {
 	Target   key.TargetID
 	Modifier info.Modifier
 	OldValue float64

--- a/pkg/engine/event/shield.go
+++ b/pkg/engine/event/shield.go
@@ -6,21 +6,21 @@ import (
 	"github.com/simimpact/srsim/pkg/key"
 )
 
-type ShieldAddedEventHandler = handler.EventHandler[ShieldAddedEvent]
-type ShieldAddedEvent struct {
+type ShieldAddedEventHandler = handler.EventHandler[ShieldAdded]
+type ShieldAdded struct {
 	ID           key.Shield
 	Info         info.Shield
 	ShieldHealth float64
 }
 
-type ShieldRemovedEventHandler = handler.EventHandler[ShieldRemovedEvent]
-type ShieldRemovedEvent struct {
+type ShieldRemovedEventHandler = handler.EventHandler[ShieldRemoved]
+type ShieldRemoved struct {
 	ID     key.Shield
 	Target key.TargetID
 }
 
-type ShieldChangeEventHandler = handler.EventHandler[ShieldChangeEvent]
-type ShieldChangeEvent struct {
+type ShieldChangeEventHandler = handler.EventHandler[ShieldChange]
+type ShieldChange struct {
 	ID     key.Shield
 	Target key.TargetID
 	OldHP  float64

--- a/pkg/engine/event/sim.go
+++ b/pkg/engine/event/sim.go
@@ -7,15 +7,15 @@ import (
 	"github.com/simimpact/srsim/pkg/model"
 )
 
-type InitializeEventHandler = handler.EventHandler[InitializeEvent]
-type InitializeEvent struct {
+type InitializeEventHandler = handler.EventHandler[Initialize]
+type Initialize struct {
 	Config *model.SimConfig
 	Seed   int64
 	// TODO: sim metadata (build date, commit hash, etc)?
 }
 
-type BattleStartEventHandler = handler.EventHandler[BattleStartEvent]
-type BattleStartEvent struct {
+type BattleStartEventHandler = handler.EventHandler[BattleStart]
+type BattleStart struct {
 	CharInfo     map[key.TargetID]info.Character
 	EnemyInfo    map[key.TargetID]info.Enemy
 	CharStats    []*info.Stats
@@ -23,37 +23,51 @@ type BattleStartEvent struct {
 	NeutralStats []*info.Stats
 }
 
-type TurnEndEventHandler = handler.EventHandler[TurnEndEvent]
-type TurnEndEvent struct {
+type TurnStartEventHandler = handler.EventHandler[TurnStart]
+type TurnStart struct {
+	Active    key.TargetID
+	DeltaAV   float64
+	TotalAV   float64
+	TurnOrder []TurnStatus
+}
+
+type TurnEndEventHandler = handler.EventHandler[TurnEnd]
+type TurnEnd struct {
 	Characters []*info.Stats
 	Enemies    []*info.Stats
 	Neutrals   []*info.Stats
 }
 
-type TerminationEventHandler = handler.EventHandler[TerminationEvent]
-type TerminationEvent struct {
+type TerminationEventHandler = handler.EventHandler[Termination]
+type Termination struct {
 	TotalAV float64
 	Reason  model.TerminationReason
 }
 
-type ActionStartEventHandler = handler.EventHandler[ActionStartEvent]
-type ActionStartEvent struct {
+type ActionStartEventHandler = handler.EventHandler[ActionStart]
+type ActionStart struct {
 	Owner      key.TargetID
 	AttackType model.AttackType
 	IsInsert   bool
 }
 
-type ActionEndEventHandler = handler.EventHandler[ActionEndEvent]
-type ActionEndEvent struct {
+type ActionEndEventHandler = handler.EventHandler[ActionEnd]
+type ActionEnd struct {
 	Owner      key.TargetID
 	Targets    map[key.TargetID]bool
 	AttackType model.AttackType
 	IsInsert   bool
 }
 
-type InsertStartEventHandler = handler.EventHandler[InsertEvent]
-type InsertEndEventHandler = handler.EventHandler[InsertEvent]
-type InsertEvent struct {
+type InsertStartEventHandler = handler.EventHandler[InsertStart]
+type InsertStart struct {
+	Owner      key.TargetID
+	AbortFlags []model.BehaviorFlag
+	Priority   info.InsertPriority
+}
+
+type InsertEndEventHandler = handler.EventHandler[InsertEnd]
+type InsertEnd struct {
 	Owner      key.TargetID
 	Targets    map[key.TargetID]bool
 	AbortFlags []model.BehaviorFlag

--- a/pkg/engine/event/sim.go
+++ b/pkg/engine/event/sim.go
@@ -43,8 +43,8 @@ type ActionStartEvent struct {
 	IsInsert   bool
 }
 
-type ActionEndEventHandler = handler.EventHandler[ActionEvent]
-type ActionEvent struct {
+type ActionEndEventHandler = handler.EventHandler[ActionEndEvent]
+type ActionEndEvent struct {
 	Owner      key.TargetID
 	Targets    map[key.TargetID]bool
 	AttackType model.AttackType

--- a/pkg/engine/event/sim.go
+++ b/pkg/engine/event/sim.go
@@ -36,7 +36,13 @@ type TerminationEvent struct {
 	Reason  model.TerminationReason
 }
 
-type ActionStartEventHandler = handler.EventHandler[ActionEvent]
+type ActionStartEventHandler = handler.EventHandler[ActionStartEvent]
+type ActionStartEvent struct {
+	Owner      key.TargetID
+	AttackType model.AttackType
+	IsInsert   bool
+}
+
 type ActionEndEventHandler = handler.EventHandler[ActionEvent]
 type ActionEvent struct {
 	Owner      key.TargetID
@@ -44,9 +50,6 @@ type ActionEvent struct {
 	AttackType model.AttackType
 	IsInsert   bool
 }
-
-type UltStartEventHandler = handler.EventHandler[ActionEvent]
-type UltEndEventHandler = handler.EventHandler[ActionEvent]
 
 type InsertStartEventHandler = handler.EventHandler[InsertEvent]
 type InsertEndEventHandler = handler.EventHandler[InsertEvent]

--- a/pkg/engine/event/turn.go
+++ b/pkg/engine/event/turn.go
@@ -11,14 +11,6 @@ type TurnTargetsAddedEvent struct {
 	TurnOrder []TurnStatus
 }
 
-type TurnStartEventHandler = handler.EventHandler[TurnStartEvent]
-type TurnStartEvent struct {
-	Active    key.TargetID
-	DeltaAV   float64
-	TotalAV   float64
-	TurnOrder []TurnStatus
-}
-
 type TurnResetEventHandler = handler.EventHandler[TurnResetEvent]
 type TurnResetEvent struct {
 	ResetTarget key.TargetID

--- a/pkg/engine/event/turn.go
+++ b/pkg/engine/event/turn.go
@@ -5,29 +5,29 @@ import (
 	"github.com/simimpact/srsim/pkg/key"
 )
 
-type TurnTargetsAddedEventHandler = handler.EventHandler[TurnTargetsAddedEvent]
-type TurnTargetsAddedEvent struct {
+type TurnTargetsAddedEventHandler = handler.EventHandler[TurnTargetsAdded]
+type TurnTargetsAdded struct {
 	Targets   []key.TargetID
 	TurnOrder []TurnStatus
 }
 
-type TurnResetEventHandler = handler.EventHandler[TurnResetEvent]
-type TurnResetEvent struct {
+type TurnResetEventHandler = handler.EventHandler[TurnReset]
+type TurnReset struct {
 	ResetTarget key.TargetID
 	GaugeCost   float64
 	TurnOrder   []TurnStatus
 }
 
-type GaugeChangeEventHandler = handler.EventHandler[GaugeChangeEvent]
-type GaugeChangeEvent struct {
+type GaugeChangeEventHandler = handler.EventHandler[GaugeChange]
+type GaugeChange struct {
 	Target    key.TargetID
 	OldGauge  float64
 	NewGauge  float64
 	TurnOrder []TurnStatus
 }
 
-type CurrentGaugeCostChangeEventHandler = handler.EventHandler[CurrentGaugeCostChangeEvent]
-type CurrentGaugeCostChangeEvent struct {
+type CurrentGaugeCostChangeEventHandler = handler.EventHandler[CurrentGaugeCostChange]
+type CurrentGaugeCostChange struct {
 	OldCost float64
 	NewCost float64
 }

--- a/pkg/engine/modifier/add.go
+++ b/pkg/engine/modifier/add.go
@@ -87,7 +87,7 @@ func (mgr *Manager) attemptResist(
 	}
 
 	// resisted, emit event
-	mgr.engine.Events().ModifierResisted.Emit(event.ModifierResistedEvent{
+	mgr.engine.Events().ModifierResisted.Emit(event.ModifierResisted{
 		Target:     target,
 		Source:     mod.Source,
 		Modifier:   mod.Name,

--- a/pkg/engine/modifier/add_test.go
+++ b/pkg/engine/modifier/add_test.go
@@ -77,7 +77,7 @@ func TestResistModifier(t *testing.T) {
 
 	expectedChance := bChance * (1 + ehr) * (1 - eres) * (1 - dres)
 
-	engine.Events().ModifierResisted.Subscribe(func(event event.ModifierResistedEvent) {
+	engine.Events().ModifierResisted.Subscribe(func(event event.ModifierResisted) {
 		assert.Equal(t, target, event.Target)
 		assert.Equal(t, source, event.Source)
 		assert.Equal(t, name, event.Modifier)
@@ -127,7 +127,7 @@ func TestFailedResist(t *testing.T) {
 
 	expectedChance := bChance * (1 + ehr) * (1 - eres) * (1 - dres)
 
-	engine.Events().ModifierResisted.Subscribe(func(event event.ModifierResistedEvent) {
+	engine.Events().ModifierResisted.Subscribe(func(event event.ModifierResisted) {
 		assert.Fail(t, "Event should never be emitted (modifier should not be resisted)")
 	})
 
@@ -198,7 +198,7 @@ func TestAddUnregistered(t *testing.T) {
 	}
 
 	called := 0
-	manager.engine.Events().ModifierAdded.Subscribe(func(event event.ModifierAddedEvent) {
+	manager.engine.Events().ModifierAdded.Subscribe(func(event event.ModifierAdded) {
 		state := event.Modifier.State.(state)
 
 		if called == 0 {
@@ -246,7 +246,7 @@ func TestAddMultiple(t *testing.T) {
 	})
 
 	called := 0
-	manager.engine.Events().ModifierAdded.Subscribe(func(event event.ModifierAddedEvent) {
+	manager.engine.Events().ModifierAdded.Subscribe(func(event event.ModifierAdded) {
 		state := event.Modifier.State.(state)
 
 		if called == 0 {
@@ -290,7 +290,7 @@ func TestAddRefresh(t *testing.T) {
 	})
 
 	addedCalls := 0
-	manager.engine.Events().ModifierAdded.Subscribe(func(event event.ModifierAddedEvent) {
+	manager.engine.Events().ModifierAdded.Subscribe(func(event event.ModifierAdded) {
 		if addedCalls == 0 {
 			assert.Equal(t, 3, event.Modifier.Duration)
 		}
@@ -298,7 +298,7 @@ func TestAddRefresh(t *testing.T) {
 	})
 
 	extendedCalls := 0
-	manager.engine.Events().ModifierExtendedDuration.Subscribe(func(event event.ModifierExtendedDurationEvent) {
+	manager.engine.Events().ModifierExtendedDuration.Subscribe(func(event event.ModifierExtendedDuration) {
 		if extendedCalls == 0 {
 			assert.Equal(t, 3, event.OldValue)
 			assert.Equal(t, 5, event.NewValue)
@@ -341,7 +341,7 @@ func TestAddProlong(t *testing.T) {
 	})
 
 	addedCalls := 0
-	manager.engine.Events().ModifierAdded.Subscribe(func(event event.ModifierAddedEvent) {
+	manager.engine.Events().ModifierAdded.Subscribe(func(event event.ModifierAdded) {
 		if addedCalls == 0 {
 			assert.Equal(t, 3, event.Modifier.Duration)
 		}
@@ -349,7 +349,7 @@ func TestAddProlong(t *testing.T) {
 	})
 
 	extendedCalls := 0
-	manager.engine.Events().ModifierExtendedDuration.Subscribe(func(event event.ModifierExtendedDurationEvent) {
+	manager.engine.Events().ModifierExtendedDuration.Subscribe(func(event event.ModifierExtendedDuration) {
 		if extendedCalls == 0 {
 			assert.Equal(t, 3, event.OldValue)
 			assert.Equal(t, 8, event.NewValue)

--- a/pkg/engine/modifier/listener.go
+++ b/pkg/engine/modifier/listener.go
@@ -132,7 +132,7 @@ type Listeners struct {
 	OnBeforeAction func(mod *Instance, e event.ActionStartEvent)
 
 	// Called when an action finishes being executed (attack, skill, ult)
-	OnAfterAction func(mod *Instance, e event.ActionEvent)
+	OnAfterAction func(mod *Instance, e event.ActionEndEvent)
 }
 
 func (mgr *Manager) subscribe() {
@@ -477,7 +477,7 @@ func (mgr *Manager) actionStart(e event.ActionStartEvent) {
 	}
 }
 
-func (mgr *Manager) actionEnd(e event.ActionEvent) {
+func (mgr *Manager) actionEnd(e event.ActionEndEvent) {
 	for _, mod := range mgr.targets[e.Owner] {
 		f := mod.listeners.OnAfterAction
 		if f != nil {

--- a/pkg/engine/modifier/listener.go
+++ b/pkg/engine/modifier/listener.go
@@ -36,7 +36,7 @@ type Listeners struct {
 	// ------------ attribute events
 
 	// Called when the current HP of the attached target changes
-	OnHPChange func(mod *Instance, e event.HPChangeEvent)
+	OnHPChange func(mod *Instance, e event.HPChange)
 
 	// Called when attached target's current HP = 0. If returns true, will cancel the event and
 	// prevent the TargetDeathEvent from occuring. Used by revives.
@@ -50,10 +50,10 @@ type Listeners struct {
 	OnTriggerDeath func(mod *Instance, target key.TargetID)
 
 	// Called whe nthe attached start
-	OnEnergyChange func(mod *Instance, e event.EnergyChangeEvent)
+	OnEnergyChange func(mod *Instance, e event.EnergyChange)
 
 	// Called when the attached target stance changes
-	OnStanceChange func(mod *Instance, e event.StanceChangeEvent)
+	OnStanceChange func(mod *Instance, e event.StanceChange)
 
 	// Called when the attached target causes another target to go into a break state (0 stance).
 	OnTriggerBreak func(mod *Instance, target key.TargetID)
@@ -388,7 +388,7 @@ func (mgr *Manager) healEnd(e event.HealEndEvent) {
 	}
 }
 
-func (mgr *Manager) hpChange(e event.HPChangeEvent) {
+func (mgr *Manager) hpChange(e event.HPChange) {
 	for _, mod := range mgr.targets[e.Target] {
 		f := mod.listeners.OnHPChange
 		if f != nil {
@@ -397,7 +397,7 @@ func (mgr *Manager) hpChange(e event.HPChangeEvent) {
 	}
 }
 
-func (mgr *Manager) limboWaitHeal(e event.LimboWaitHealEvent) bool {
+func (mgr *Manager) limboWaitHeal(e event.LimboWaitHeal) bool {
 	for _, mod := range mgr.targets[e.Target] {
 		f := mod.listeners.OnLimboWaitHeal
 		if f != nil {
@@ -410,7 +410,7 @@ func (mgr *Manager) limboWaitHeal(e event.LimboWaitHealEvent) bool {
 	return false
 }
 
-func (mgr *Manager) targetDeath(e event.TargetDeathEvent) {
+func (mgr *Manager) targetDeath(e event.TargetDeath) {
 	for _, mod := range mgr.targets[e.Target] {
 		f := mod.listeners.OnBeforeDying
 		if f != nil {
@@ -426,7 +426,7 @@ func (mgr *Manager) targetDeath(e event.TargetDeathEvent) {
 	}
 }
 
-func (mgr *Manager) energyChange(e event.EnergyChangeEvent) {
+func (mgr *Manager) energyChange(e event.EnergyChange) {
 	for _, mod := range mgr.targets[e.Target] {
 		f := mod.listeners.OnEnergyChange
 		if f != nil {
@@ -435,7 +435,7 @@ func (mgr *Manager) energyChange(e event.EnergyChangeEvent) {
 	}
 }
 
-func (mgr *Manager) stanceChange(e event.StanceChangeEvent) {
+func (mgr *Manager) stanceChange(e event.StanceChange) {
 	for _, mod := range mgr.targets[e.Target] {
 		f := mod.listeners.OnStanceChange
 		if f != nil {
@@ -444,7 +444,7 @@ func (mgr *Manager) stanceChange(e event.StanceChangeEvent) {
 	}
 }
 
-func (mgr *Manager) stanceBreak(e event.StanceBreakEvent) {
+func (mgr *Manager) stanceBreak(e event.StanceBreak) {
 	for _, mod := range mgr.targets[e.Source] {
 		f := mod.listeners.OnTriggerBreak
 		if f != nil {
@@ -459,7 +459,7 @@ func (mgr *Manager) stanceBreak(e event.StanceBreakEvent) {
 	}
 }
 
-func (mgr *Manager) stanceBreakEnd(e event.StanceResetEvent) {
+func (mgr *Manager) stanceBreakEnd(e event.StanceReset) {
 	for _, mod := range mgr.targets[e.Target] {
 		f := mod.listeners.OnEndBreak
 		if f != nil {

--- a/pkg/engine/modifier/listener.go
+++ b/pkg/engine/modifier/listener.go
@@ -129,7 +129,7 @@ type Listeners struct {
 	// ------------ sim events
 
 	// Called when an action starts being executed (attack, skill, ult)
-	OnBeforeAction func(mod *Instance, e event.ActionEvent)
+	OnBeforeAction func(mod *Instance, e event.ActionStartEvent)
 
 	// Called when an action finishes being executed (attack, skill, ult)
 	OnAfterAction func(mod *Instance, e event.ActionEvent)
@@ -141,8 +141,6 @@ func (mgr *Manager) subscribe() {
 	// sim events
 	events.ActionStart.Subscribe(mgr.actionStart)
 	events.ActionEnd.Subscribe(mgr.actionEnd)
-	events.UltStart.Subscribe(mgr.actionStart)
-	events.UltEnd.Subscribe(mgr.actionEnd)
 
 	// attribute events
 	events.HPChange.Subscribe(mgr.hpChange)
@@ -470,7 +468,7 @@ func (mgr *Manager) stanceBreakEnd(e event.StanceBreakEndEvent) {
 	}
 }
 
-func (mgr *Manager) actionStart(e event.ActionEvent) {
+func (mgr *Manager) actionStart(e event.ActionStartEvent) {
 	for _, mod := range mgr.targets[e.Owner] {
 		f := mod.listeners.OnBeforeAction
 		if f != nil {

--- a/pkg/engine/modifier/listener.go
+++ b/pkg/engine/modifier/listener.go
@@ -67,10 +67,10 @@ type Listeners struct {
 	// ------------ shield events
 
 	// Called when a shield has been added to the attached target.
-	OnShieldAdded func(mod *Instance, e event.ShieldAddedEvent)
+	OnShieldAdded func(mod *Instance, e event.ShieldAdded)
 
 	// Called when a shield has been removed from the attached target.
-	OnShieldRemoved func(mod *Instance, e event.ShieldRemovedEvent)
+	OnShieldRemoved func(mod *Instance, e event.ShieldRemoved)
 
 	// ------------ combat events
 
@@ -486,7 +486,7 @@ func (mgr *Manager) actionEnd(e event.ActionEnd) {
 	}
 }
 
-func (mgr *Manager) shieldAdded(e event.ShieldAddedEvent) {
+func (mgr *Manager) shieldAdded(e event.ShieldAdded) {
 	for _, mod := range mgr.targets[e.Info.Target] {
 		f := mod.listeners.OnShieldAdded
 		if f != nil {
@@ -495,7 +495,7 @@ func (mgr *Manager) shieldAdded(e event.ShieldAddedEvent) {
 	}
 }
 
-func (mgr *Manager) shieldRemoved(e event.ShieldRemovedEvent) {
+func (mgr *Manager) shieldRemoved(e event.ShieldRemoved) {
 	for _, mod := range mgr.targets[e.Target] {
 		f := mod.listeners.OnShieldRemoved
 		if f != nil {

--- a/pkg/engine/modifier/listener.go
+++ b/pkg/engine/modifier/listener.go
@@ -178,7 +178,7 @@ func (mgr *Manager) emitAdd(target key.TargetID, mod *Instance, chance float64) 
 	if f != nil {
 		f(mod)
 	}
-	mgr.engine.Events().ModifierAdded.Emit(event.ModifierAddedEvent{
+	mgr.engine.Events().ModifierAdded.Emit(event.ModifierAdded{
 		Target:   target,
 		Modifier: mod.ToModel(),
 		Chance:   chance,
@@ -195,7 +195,7 @@ func (mgr *Manager) emitRemove(target key.TargetID, mods []*Instance) {
 		if f != nil {
 			f(mod)
 		}
-		mgr.engine.Events().ModifierRemoved.Emit(event.ModifierRemovedEvent{
+		mgr.engine.Events().ModifierRemoved.Emit(event.ModifierRemoved{
 			Target:   target,
 			Modifier: mod.ToModel(),
 		})
@@ -207,7 +207,7 @@ func (mgr *Manager) emitExtendDuration(target key.TargetID, mod *Instance, old i
 	if f != nil {
 		f(mod)
 	}
-	mgr.engine.Events().ModifierExtendedDuration.Emit(event.ModifierExtendedDurationEvent{
+	mgr.engine.Events().ModifierExtendedDuration.Emit(event.ModifierExtendedDuration{
 		Target:   target,
 		Modifier: mod.ToModel(),
 		OldValue: old,
@@ -220,7 +220,7 @@ func (mgr *Manager) emitExtendCount(target key.TargetID, mod *Instance, old floa
 	if f != nil {
 		f(mod)
 	}
-	mgr.engine.Events().ModifierExtendedCount.Emit(event.ModifierExtendedCountEvent{
+	mgr.engine.Events().ModifierExtendedCount.Emit(event.ModifierExtendedCount{
 		Target:   target,
 		Modifier: mod.ToModel(),
 		OldValue: old,

--- a/pkg/engine/modifier/listener.go
+++ b/pkg/engine/modifier/listener.go
@@ -149,7 +149,7 @@ func (mgr *Manager) subscribe() {
 	events.EnergyChange.Subscribe(mgr.energyChange)
 	events.StanceChange.Subscribe(mgr.stanceChange)
 	events.StanceBreak.Subscribe(mgr.stanceBreak)
-	events.StanceBreakEnd.Subscribe(mgr.stanceBreakEnd)
+	events.StanceReset.Subscribe(mgr.stanceBreakEnd)
 
 	// shield events
 	events.ShieldAdded.Subscribe(mgr.shieldAdded)
@@ -459,7 +459,7 @@ func (mgr *Manager) stanceBreak(e event.StanceBreakEvent) {
 	}
 }
 
-func (mgr *Manager) stanceBreakEnd(e event.StanceBreakEndEvent) {
+func (mgr *Manager) stanceBreakEnd(e event.StanceResetEvent) {
 	for _, mod := range mgr.targets[e.Target] {
 		f := mod.listeners.OnEndBreak
 		if f != nil {

--- a/pkg/engine/modifier/listener.go
+++ b/pkg/engine/modifier/listener.go
@@ -129,10 +129,10 @@ type Listeners struct {
 	// ------------ sim events
 
 	// Called when an action starts being executed (attack, skill, ult)
-	OnBeforeAction func(mod *Instance, e event.ActionStartEvent)
+	OnBeforeAction func(mod *Instance, e event.ActionStart)
 
 	// Called when an action finishes being executed (attack, skill, ult)
-	OnAfterAction func(mod *Instance, e event.ActionEndEvent)
+	OnAfterAction func(mod *Instance, e event.ActionEnd)
 }
 
 func (mgr *Manager) subscribe() {
@@ -468,7 +468,7 @@ func (mgr *Manager) stanceBreakEnd(e event.StanceReset) {
 	}
 }
 
-func (mgr *Manager) actionStart(e event.ActionStartEvent) {
+func (mgr *Manager) actionStart(e event.ActionStart) {
 	for _, mod := range mgr.targets[e.Owner] {
 		f := mod.listeners.OnBeforeAction
 		if f != nil {
@@ -477,7 +477,7 @@ func (mgr *Manager) actionStart(e event.ActionStartEvent) {
 	}
 }
 
-func (mgr *Manager) actionEnd(e event.ActionEndEvent) {
+func (mgr *Manager) actionEnd(e event.ActionEnd) {
 	for _, mod := range mgr.targets[e.Owner] {
 		f := mod.listeners.OnAfterAction
 		if f != nil {

--- a/pkg/engine/modifier/listener.go
+++ b/pkg/engine/modifier/listener.go
@@ -75,56 +75,56 @@ type Listeners struct {
 	// ------------ combat events
 
 	// Called when an attack starts and the attached target is the attacker.
-	OnBeforeAttack func(mod *Instance, e event.AttackStartEvent)
+	OnBeforeAttack func(mod *Instance, e event.AttackStart)
 
 	// Called when an attack starts and the attached target is one of the targets being attacked.
-	OnBeforeBeingAttacked func(mod *Instance, e event.AttackStartEvent)
+	OnBeforeBeingAttacked func(mod *Instance, e event.AttackStart)
 
 	// Called after an attack finishes (after all hits) and the attached target is the attacker
-	OnAfterAttack func(mod *Instance, e event.AttackEndEvent)
+	OnAfterAttack func(mod *Instance, e event.AttackEnd)
 
 	// Called after an attack finishes (after all hits) and the attached target was hit by the attack.
-	OnAfterBeingAttacked func(mod *Instance, e event.AttackEndEvent)
+	OnAfterBeingAttacked func(mod *Instance, e event.AttackEnd)
 
 	// Called before any hit occurs and the attached target is the attacker. Hit data is mutable.
-	OnBeforeHitAll func(mod *Instance, e event.HitStartEvent)
+	OnBeforeHitAll func(mod *Instance, e event.HitStart)
 
 	// Called before a qualified hit occurs and the attached target is the attacker. "Qualified" hit
 	// means it is not of AttackType DOT, PURSUED, or ELEMENT_DAMAGE. Hit data is mutable.
-	OnBeforeHit func(mod *Instance, e event.HitStartEvent)
+	OnBeforeHit func(mod *Instance, e event.HitStart)
 
 	// called before any hit occurs and the attached target is the defender. Hit data is mutable.
-	OnBeforeBeingHitAll func(mod *Instance, e event.HitStartEvent)
+	OnBeforeBeingHitAll func(mod *Instance, e event.HitStart)
 
 	// Called before a qualified hit occurs and the attached target is the defender. "Qualified" hit
 	// means it is not of AttackType DOT, PURSUED, or ELEMENT_DAMAGE. Hit data is mutable.
-	OnBeforeBeingHit func(mod *Instance, e event.HitStartEvent)
+	OnBeforeBeingHit func(mod *Instance, e event.HitStart)
 
 	// Called after any hit occurs and the attached target is the attacker.
-	OnAfterHitAll func(mod *Instance, e event.HitEndEvent)
+	OnAfterHitAll func(mod *Instance, e event.HitEnd)
 
 	// Called after a qualified hit occurs and the attached target is the attacker. "Qualified" hit
 	// means it is not of AttackType DOT, PURSUED, or ELEMENT_DAMAGE.
-	OnAfterHit func(mod *Instance, e event.HitEndEvent)
+	OnAfterHit func(mod *Instance, e event.HitEnd)
 
 	// Called after any hit occurs and the attached target is the defender.
-	OnAfterBeingHitAll func(mod *Instance, e event.HitEndEvent)
+	OnAfterBeingHitAll func(mod *Instance, e event.HitEnd)
 
 	// Called after a qualified hit occurs and the attached target is the defender. "Qualified" hit
 	// means it is not of AttackType DOT, PURSUED, or ELEMENT_DAMAGE.
-	OnAfterBeingHit func(mod *Instance, e event.HitEndEvent)
+	OnAfterBeingHit func(mod *Instance, e event.HitEnd)
 
 	// Called before performing a heal and the attached target is the healer. Heal data is mutable.
-	OnBeforeDealHeal func(mod *Instance, e *event.HealStartEvent)
+	OnBeforeDealHeal func(mod *Instance, e *event.HealStart)
 
 	// Called before performing a heal and the attached target is the receiver. Heal data is mutable.
-	OnBeforeBeingHeal func(mod *Instance, e *event.HealStartEvent)
+	OnBeforeBeingHeal func(mod *Instance, e *event.HealStart)
 
 	// Called after a heal is performed and the attached target is the healer.
-	OnAfterDealHeal func(mod *Instance, e event.HealEndEvent)
+	OnAfterDealHeal func(mod *Instance, e event.HealEnd)
 
 	// Called after a heal is performed and the attached target is the receiver
-	OnAfterBeingHeal func(mod *Instance, e event.HealEndEvent)
+	OnAfterBeingHeal func(mod *Instance, e event.HealEnd)
 
 	// ------------ sim events
 
@@ -228,7 +228,7 @@ func (mgr *Manager) emitExtendCount(target key.TargetID, mod *Instance, old floa
 	})
 }
 
-func (mgr *Manager) attackStart(e event.AttackStartEvent) {
+func (mgr *Manager) attackStart(e event.AttackStart) {
 	for _, mod := range mgr.targets[e.Attacker] {
 		f := mod.listeners.OnBeforeAttack
 		if f != nil {
@@ -245,7 +245,7 @@ func (mgr *Manager) attackStart(e event.AttackStartEvent) {
 	}
 }
 
-func (mgr *Manager) attackEnd(e event.AttackEndEvent) {
+func (mgr *Manager) attackEnd(e event.AttackEnd) {
 	for _, mod := range mgr.targets[e.Attacker] {
 		f := mod.listeners.OnAfterAttack
 		if f != nil {
@@ -262,7 +262,7 @@ func (mgr *Manager) attackEnd(e event.AttackEndEvent) {
 	}
 }
 
-func (mgr *Manager) hitStart(e event.HitStartEvent) {
+func (mgr *Manager) hitStart(e event.HitStart) {
 	qualified := e.Hit.AttackType.IsQualified()
 	snapshot := e.Hit.UseSnapshot
 
@@ -299,7 +299,7 @@ func (mgr *Manager) hitStart(e event.HitStartEvent) {
 	}
 }
 
-func (mgr *Manager) hitEnd(e event.HitEndEvent) {
+func (mgr *Manager) hitEnd(e event.HitEnd) {
 	qualified := e.AttackType.IsQualified()
 	snapshot := e.UseSnapshot
 
@@ -336,7 +336,7 @@ func (mgr *Manager) hitEnd(e event.HitEndEvent) {
 	}
 }
 
-func (mgr *Manager) healStart(e *event.HealStartEvent) {
+func (mgr *Manager) healStart(e *event.HealStart) {
 	snapshot := e.UseSnapshot
 
 	for _, mod := range mgr.targets[e.Healer.ID()] {
@@ -362,7 +362,7 @@ func (mgr *Manager) healStart(e *event.HealStartEvent) {
 	}
 }
 
-func (mgr *Manager) healEnd(e event.HealEndEvent) {
+func (mgr *Manager) healEnd(e event.HealEnd) {
 	snapshot := e.UseSnapshot
 
 	for _, mod := range mgr.targets[e.Healer] {

--- a/pkg/engine/modifier/remove_test.go
+++ b/pkg/engine/modifier/remove_test.go
@@ -75,7 +75,7 @@ func TestRemoveModifier(t *testing.T) {
 	manager.targets[target] = append(manager.targets[target], mod3, mod1, mod2)
 
 	called := 0
-	manager.engine.Events().ModifierRemoved.Subscribe(func(event event.ModifierRemovedEvent) {
+	manager.engine.Events().ModifierRemoved.Subscribe(func(event event.ModifierRemoved) {
 		assert.Equal(t, modsToRemove, event.Modifier.Name)
 		called += 1
 	})
@@ -108,7 +108,7 @@ func TestRemoveModifierFromSource(t *testing.T) {
 	manager.targets[target] = append(manager.targets[target], mod3, mod2, mod1)
 
 	called := 0
-	manager.engine.Events().ModifierRemoved.Subscribe(func(event event.ModifierRemovedEvent) {
+	manager.engine.Events().ModifierRemoved.Subscribe(func(event event.ModifierRemoved) {
 		assert.Equal(t, modsToRemove, event.Modifier.Name)
 		called += 1
 	})
@@ -145,7 +145,7 @@ func TestRemoveModifierWithOnRemoveListener(t *testing.T) {
 	manager.targets[target] = append(manager.targets[target], mod)
 
 	called := 0
-	manager.engine.Events().ModifierRemoved.Subscribe(func(event event.ModifierRemovedEvent) {
+	manager.engine.Events().ModifierRemoved.Subscribe(func(event event.ModifierRemoved) {
 		state := event.Modifier.State.(*state)
 		assert.Equal(t, name, event.Modifier.Name)
 		assert.True(t, state.OnRemoveCalled)
@@ -184,7 +184,7 @@ func TestRemoveModifierSelf(t *testing.T) {
 	manager.targets[target] = append(manager.targets[target], mod)
 
 	called := 0
-	manager.engine.Events().ModifierRemoved.Subscribe(func(event event.ModifierRemovedEvent) {
+	manager.engine.Events().ModifierRemoved.Subscribe(func(event event.ModifierRemoved) {
 		state := event.Modifier.State.(*state)
 		assert.Equal(t, name, event.Modifier.Name)
 		assert.True(t, state.OnRemoveCalled)

--- a/pkg/engine/modifier/update_test.go
+++ b/pkg/engine/modifier/update_test.go
@@ -40,7 +40,7 @@ func TestExtendDuration(t *testing.T) {
 	manager.targets[target] = append(manager.targets[target], mod1, mod2, mod3)
 
 	called := 0
-	manager.engine.Events().ModifierExtendedDuration.Subscribe(func(event event.ModifierExtendedDurationEvent) {
+	manager.engine.Events().ModifierExtendedDuration.Subscribe(func(event event.ModifierExtendedDuration) {
 		switch called {
 		case 0:
 			assert.Equal(t, 0, event.OldValue)
@@ -92,7 +92,7 @@ func TestExtendCount(t *testing.T) {
 	manager.targets[target] = append(manager.targets[target], mod1, mod2, mod3)
 
 	called := 0
-	manager.engine.Events().ModifierExtendedCount.Subscribe(func(event event.ModifierExtendedCountEvent) {
+	manager.engine.Events().ModifierExtendedCount.Subscribe(func(event event.ModifierExtendedCount) {
 		switch called {
 		case 0:
 			assert.Equal(t, 0.0, event.OldValue)

--- a/pkg/engine/shield/absorb.go
+++ b/pkg/engine/shield/absorb.go
@@ -21,7 +21,7 @@ func (mgr *Manager) AbsorbDamage(target key.TargetID, damage float64) float64 {
 		if shield.HP < 0 {
 			shield.HP = 0
 		}
-		mgr.event.ShieldChange.Emit(event.ShieldChangeEvent{
+		mgr.event.ShieldChange.Emit(event.ShieldChange{
 			ID:     id,
 			Target: target,
 			OldHP:  prevHP,

--- a/pkg/engine/shield/add.go
+++ b/pkg/engine/shield/add.go
@@ -15,7 +15,7 @@ func (mgr *Manager) AddShield(id key.Shield, shield info.Shield) {
 	// 5. emit ShieldAdded event
 
 	// emit to signify shield added
-	mgr.event.ShieldAdded.Emit(event.ShieldAddedEvent{
+	mgr.event.ShieldAdded.Emit(event.ShieldAdded{
 		ID:           id,
 		Info:         shield,
 		ShieldHealth: 0, // TODO: populate

--- a/pkg/engine/shield/remove.go
+++ b/pkg/engine/shield/remove.go
@@ -13,7 +13,7 @@ func (mgr *Manager) RemoveShield(id key.Shield, target key.TargetID) {
 
 	delete(mgr.targets[target], id)
 
-	mgr.event.ShieldRemoved.Emit(event.ShieldRemovedEvent{
+	mgr.event.ShieldRemoved.Emit(event.ShieldRemoved{
 		ID:     id,
 		Target: target,
 	})

--- a/pkg/engine/target/character/add.go
+++ b/pkg/engine/target/character/add.go
@@ -111,7 +111,7 @@ func (mgr *Manager) AddCharacter(id key.TargetID, char *model.Character) error {
 		f(mgr.engine, id)
 	}
 
-	mgr.engine.Events().CharacterAdded.Emit(event.CharacterAddedEvent{
+	mgr.engine.Events().CharacterAdded.Emit(event.CharacterAdded{
 		ID:   id,
 		Info: info,
 	})

--- a/pkg/engine/target/enemy/add.go
+++ b/pkg/engine/target/enemy/add.go
@@ -71,7 +71,7 @@ func (mgr *Manager) AddEnemy(id key.TargetID, enemy *model.Enemy) error {
 	}
 	mgr.info[id] = info
 
-	mgr.engine.Events().EnemyAdded.Emit(event.EnemyAddedEvent{
+	mgr.engine.Events().EnemyAdded.Emit(event.EnemyAdded{
 		ID:   id,
 		Info: info,
 	})

--- a/pkg/engine/turn/modify.go
+++ b/pkg/engine/turn/modify.go
@@ -44,7 +44,7 @@ func (mgr *Manager) SetGauge(target key.TargetID, amt float64) error {
 		}
 	}
 
-	mgr.event.GaugeChange.Emit(event.GaugeChangeEvent{
+	mgr.event.GaugeChange.Emit(event.GaugeChange{
 		Target:    target,
 		OldGauge:  prev,
 		NewGauge:  mgr.target(target).gauge,
@@ -82,7 +82,7 @@ func (mgr *Manager) SetCurrentGaugeCost(amt float64) {
 		return
 	}
 
-	mgr.event.CurrentGaugeCostChange.Emit(event.CurrentGaugeCostChangeEvent{
+	mgr.event.CurrentGaugeCostChange.Emit(event.CurrentGaugeCostChange{
 		OldCost: prev,
 		NewCost: mgr.gaugeCost,
 	})

--- a/pkg/engine/turn/turn.go
+++ b/pkg/engine/turn/turn.go
@@ -114,7 +114,7 @@ func (mgr *Manager) StartTurn() (key.TargetID, float64, error) {
 	// 	5. Emit TurnStartEvent
 
 	mgr.totalAV += av
-	mgr.event.TurnStart.Emit(event.TurnStartEvent{
+	mgr.event.TurnStart.Emit(event.TurnStart{
 		Active:    mgr.activeTarget,
 		DeltaAV:   av,
 		TotalAV:   mgr.totalAV,

--- a/pkg/engine/turn/turn.go
+++ b/pkg/engine/turn/turn.go
@@ -73,7 +73,7 @@ func (mgr *Manager) AddTargets(ids ...key.TargetID) {
 	// TODO: sort the order array based on each target's AV. This sort algorithm must be stable.
 	//		update targetIndexes based off the new positions post sort.
 
-	mgr.event.TurnTargetsAdded.Emit(event.TurnTargetsAddedEvent{
+	mgr.event.TurnTargetsAdded.Emit(event.TurnTargetsAdded{
 		Targets:   ids,
 		TurnOrder: []event.TurnStatus{}, // TODO: populate
 	})
@@ -145,7 +145,7 @@ func (mgr *Manager) ResetTurn() error {
 	// 4. update targetIndexes for all targets that moved in the order (or just repopulate all)
 	// 5. emit TurnResetEvent
 
-	mgr.event.TurnReset.Emit(event.TurnResetEvent{
+	mgr.event.TurnReset.Emit(event.TurnReset{
 		ResetTarget: mgr.activeTarget,
 		GaugeCost:   mgr.gaugeCost,
 		TurnOrder:   []event.TurnStatus{}, // TODO: need to populate based on new order

--- a/pkg/simulation/action.go
+++ b/pkg/simulation/action.go
@@ -130,7 +130,7 @@ func (sim *Simulation) executeAction(id key.TargetID, isInsert bool) error {
 
 	sim.ModifySP(executable.SPDelta)
 	sim.clearActionTargets()
-	sim.Event.ActionStart.Emit(event.ActionStartEvent{
+	sim.Event.ActionStart.Emit(event.ActionStart{
 		Owner:      id,
 		AttackType: executable.AttackType,
 		IsInsert:   isInsert,
@@ -142,7 +142,7 @@ func (sim *Simulation) executeAction(id key.TargetID, isInsert bool) error {
 	// end attack if in one. no-op if not in an attack
 	// emit end events
 	sim.Combat.EndAttack()
-	sim.Event.ActionEnd.Emit(event.ActionEndEvent{
+	sim.Event.ActionEnd.Emit(event.ActionEnd{
 		Owner:      id,
 		Targets:    sim.ActionTargets,
 		AttackType: executable.AttackType,
@@ -167,7 +167,7 @@ func (sim *Simulation) executeUlt(act actionPkg.Action) error {
 	}
 
 	sim.clearActionTargets()
-	sim.Event.ActionStart.Emit(event.ActionStartEvent{
+	sim.Event.ActionStart.Emit(event.ActionStart{
 		Owner:      id,
 		AttackType: model.AttackType_ULT,
 		IsInsert:   true,
@@ -177,7 +177,7 @@ func (sim *Simulation) executeUlt(act actionPkg.Action) error {
 
 	// end attack if in one. no-op if not in an attack
 	sim.Combat.EndAttack()
-	sim.Event.ActionEnd.Emit(event.ActionEndEvent{
+	sim.Event.ActionEnd.Emit(event.ActionEnd{
 		Owner:      id,
 		Targets:    sim.ActionTargets,
 		AttackType: model.AttackType_ULT,
@@ -188,9 +188,8 @@ func (sim *Simulation) executeUlt(act actionPkg.Action) error {
 
 func (sim *Simulation) executeInsert(i info.Insert) {
 	sim.clearActionTargets()
-	sim.Event.InsertStart.Emit(event.InsertEvent{
+	sim.Event.InsertStart.Emit(event.InsertStart{
 		Owner:      i.Source,
-		Targets:    nil,
 		AbortFlags: i.AbortFlags,
 		Priority:   i.Priority,
 	})
@@ -200,7 +199,7 @@ func (sim *Simulation) executeInsert(i info.Insert) {
 
 	// end attack if in one. no-op if not in an attack
 	sim.Combat.EndAttack()
-	sim.Event.InsertEnd.Emit(event.InsertEvent{
+	sim.Event.InsertEnd.Emit(event.InsertEnd{
 		Owner:      i.Source,
 		Targets:    sim.ActionTargets,
 		AbortFlags: i.AbortFlags,

--- a/pkg/simulation/action.go
+++ b/pkg/simulation/action.go
@@ -132,6 +132,7 @@ func (sim *Simulation) executeAction(id key.TargetID, isInsert bool) error {
 	sim.clearActionTargets()
 	sim.Event.ActionStart.Emit(event.ActionEvent{
 		Owner:      id,
+		Targets:    nil,
 		AttackType: executable.AttackType,
 		IsInsert:   isInsert,
 	})
@@ -169,6 +170,7 @@ func (sim *Simulation) executeUlt(act actionPkg.Action) error {
 	sim.clearActionTargets()
 	sim.Event.UltStart.Emit(event.ActionEvent{
 		Owner:      id,
+		Targets:    nil,
 		AttackType: model.AttackType_ULT,
 		IsInsert:   true,
 	})
@@ -190,6 +192,7 @@ func (sim *Simulation) executeInsert(i info.Insert) {
 	sim.clearActionTargets()
 	sim.Event.InsertStart.Emit(event.InsertEvent{
 		Owner:      i.Source,
+		Targets:    nil,
 		AbortFlags: i.AbortFlags,
 		Priority:   i.Priority,
 	})

--- a/pkg/simulation/action.go
+++ b/pkg/simulation/action.go
@@ -142,7 +142,7 @@ func (sim *Simulation) executeAction(id key.TargetID, isInsert bool) error {
 	// end attack if in one. no-op if not in an attack
 	// emit end events
 	sim.Combat.EndAttack()
-	sim.Event.ActionEnd.Emit(event.ActionEvent{
+	sim.Event.ActionEnd.Emit(event.ActionEndEvent{
 		Owner:      id,
 		Targets:    sim.ActionTargets,
 		AttackType: executable.AttackType,
@@ -177,7 +177,7 @@ func (sim *Simulation) executeUlt(act actionPkg.Action) error {
 
 	// end attack if in one. no-op if not in an attack
 	sim.Combat.EndAttack()
-	sim.Event.ActionEnd.Emit(event.ActionEvent{
+	sim.Event.ActionEnd.Emit(event.ActionEndEvent{
 		Owner:      id,
 		Targets:    sim.ActionTargets,
 		AttackType: model.AttackType_ULT,

--- a/pkg/simulation/action.go
+++ b/pkg/simulation/action.go
@@ -130,9 +130,8 @@ func (sim *Simulation) executeAction(id key.TargetID, isInsert bool) error {
 
 	sim.ModifySP(executable.SPDelta)
 	sim.clearActionTargets()
-	sim.Event.ActionStart.Emit(event.ActionEvent{
+	sim.Event.ActionStart.Emit(event.ActionStartEvent{
 		Owner:      id,
-		Targets:    nil,
 		AttackType: executable.AttackType,
 		IsInsert:   isInsert,
 	})
@@ -168,9 +167,8 @@ func (sim *Simulation) executeUlt(act actionPkg.Action) error {
 	}
 
 	sim.clearActionTargets()
-	sim.Event.UltStart.Emit(event.ActionEvent{
+	sim.Event.ActionStart.Emit(event.ActionStartEvent{
 		Owner:      id,
-		Targets:    nil,
 		AttackType: model.AttackType_ULT,
 		IsInsert:   true,
 	})
@@ -179,7 +177,7 @@ func (sim *Simulation) executeUlt(act actionPkg.Action) error {
 
 	// end attack if in one. no-op if not in an attack
 	sim.Combat.EndAttack()
-	sim.Event.UltEnd.Emit(event.ActionEvent{
+	sim.Event.ActionEnd.Emit(event.ActionEvent{
 		Owner:      id,
 		Targets:    sim.ActionTargets,
 		AttackType: model.AttackType_ULT,

--- a/pkg/simulation/attribute.go
+++ b/pkg/simulation/attribute.go
@@ -15,7 +15,7 @@ func (sim *Simulation) ModifySP(amt int) int {
 	}
 
 	if old != sim.Sp {
-		sim.Event.SPChange.Emit(event.SPChangeEvent{
+		sim.Event.SPChange.Emit(event.SPChange{
 			OldSP: old,
 			NewSP: sim.Sp,
 		})

--- a/pkg/simulation/helper.go
+++ b/pkg/simulation/helper.go
@@ -41,7 +41,7 @@ func (sim *Simulation) createSnapshot() snapshot {
 func (sim *Simulation) deathCheck(targets []key.TargetID) {
 	for _, target := range targets {
 		if sim.Attr.HPRatio(target) <= 0 {
-			sim.Event.TargetDeath.Emit(event.TargetDeathEvent{
+			sim.Event.TargetDeath.Emit(event.TargetDeath{
 				Target: target,
 				Killer: target,
 			})

--- a/pkg/simulation/hook.go
+++ b/pkg/simulation/hook.go
@@ -10,7 +10,7 @@ func (sim *Simulation) subscribe() {
 	sim.Event.TargetDeath.Subscribe(sim.onDeath)
 }
 
-func (sim *Simulation) onDeath(e event.TargetDeathEvent) {
+func (sim *Simulation) onDeath(e event.TargetDeath) {
 	// remove this target from active arrays (these arrays represent order in battle map)
 	switch sim.Targets[e.Target] {
 	case info.ClassCharacter:

--- a/pkg/simulation/run.go
+++ b/pkg/simulation/run.go
@@ -42,7 +42,7 @@ func initialize(sim *Simulation) (stateFn, error) {
 	// TODO: stats collectors should enable here?
 
 	// want to emit after all hooks in the event that they subscribe to these
-	sim.Event.Initialize.Emit(event.InitializeEvent{
+	sim.Event.Initialize.Emit(event.Initialize{
 		Config: sim.cfg,
 		Seed:   sim.seed,
 	})
@@ -95,7 +95,7 @@ func startBattle(sim *Simulation) (stateFn, error) {
 
 	// emit BattleStart event to log the "start state" of everything
 	snap := sim.createSnapshot()
-	sim.Event.BattleStart.Emit(event.BattleStartEvent{
+	sim.Event.BattleStart.Emit(event.BattleStart{
 		CharInfo:     sim.Char.Characters(),
 		EnemyInfo:    sim.Enemy.Enemies(),
 		CharStats:    snap.characters,
@@ -191,7 +191,7 @@ func endTurn(sim *Simulation) (stateFn, error) {
 
 	// emit TurnEnd event to log the current state of all remaining targets
 	snap := sim.createSnapshot()
-	sim.Event.TurnEnd.Emit(event.TurnEndEvent{
+	sim.Event.TurnEnd.Emit(event.TurnEnd{
 		Characters: snap.characters,
 		Enemies:    snap.enemies,
 		Neutrals:   snap.neutrals,
@@ -213,7 +213,7 @@ func (sim *Simulation) exitCheck(next stateFn) (stateFn, error) {
 	}
 
 	if reason != model.TerminationReason_INVALID_TERMINATION {
-		sim.Event.Termination.Emit(event.TerminationEvent{
+		sim.Event.Termination.Emit(event.Termination{
 			TotalAV: sim.TotalAV,
 			Reason:  reason,
 		})

--- a/testframe/eventchecker/battlestart/battle_start_checker.go
+++ b/testframe/eventchecker/battlestart/battle_start_checker.go
@@ -10,7 +10,7 @@ import (
 
 func ExpectOnly() teststub.EventChecker {
 	return func(e handler.Event) (bool, error) {
-		_, ok := e.(event.BattleStartEvent)
+		_, ok := e.(event.BattleStart)
 		if !ok {
 			return false, fmt.Errorf("incorrect Event %T", e)
 		}
@@ -20,7 +20,7 @@ func ExpectOnly() teststub.EventChecker {
 
 func ExpectFor() teststub.EventChecker {
 	return func(e handler.Event) (bool, error) {
-		_, ok := e.(event.BattleStartEvent)
+		_, ok := e.(event.BattleStart)
 		if !ok {
 			return false, nil
 		}

--- a/testframe/eventchecker/termination/termination_checker.go
+++ b/testframe/eventchecker/termination/termination_checker.go
@@ -8,7 +8,7 @@ import (
 
 func ExpectFor() teststub.EventChecker {
 	return func(e handler.Event) (bool, error) {
-		_, ok := e.(event.TerminationEvent)
+		_, ok := e.(event.Termination)
 		if !ok {
 			return false, nil
 		}


### PR DESCRIPTION
Attempting to improve code readability and follow stutter practices by removing the redundant `Event` suffix from all event names (code goes from `event.HitStartEvent` -> `event.HitStart`)