### PR TITLE
change return to nil on err

### DIFF
--- a/pkg/simulation/action.go
+++ b/pkg/simulation/action.go
@@ -81,7 +81,7 @@ func (sim *Simulation) ultCheck() error {
 func (sim *Simulation) executeQueue(phase info.BattlePhase, next stateFn) (stateFn, error) {
 	// always ult check when calling executeQueue
 	if err := sim.ultCheck(); err != nil {
-		return next, err
+		return nil, err
 	}
 
 	// if active is not a character, cannot prform any queue execution until after ActionEnd
@@ -111,7 +111,7 @@ func (sim *Simulation) executeQueue(phase info.BattlePhase, next stateFn) (state
 			return next, err
 		}
 		if err := sim.ultCheck(); err != nil {
-			return next, err
+			return nil, err
 		}
 	}
 	return next, nil


### PR DESCRIPTION
```go
// execute everything on the queue. After queue execution is complete, return the next stateFn
// as the next state to run. This logic will run the exitCheck on each execution. If an exit
// condition is met, will return that state instead
func (sim *Simulation) executeQueue(phase info.BattlePhase, next stateFn) (stateFn, error) {
	// always ult check when calling executeQueue
	if err := sim.ultCheck(); err != nil {
		return next, err
	}
```

Looking at this code block, I think the intention here is `return nil, err`, since err is not nil, next should be ignored by the core state loop. Was a little confused on why the return is `next` here