### PR TITLE
Add `CanModifySnapshot: true` to instances of modifiers with the new `ModifyDotDamageData` behavior flag

### DIFF
--- a/internal/character/danheng/eidolon.go
+++ b/internal/character/danheng/eidolon.go
@@ -23,6 +23,7 @@ func init() {
 				}
 			},
 		},
+		CanModifySnapshot: true,
 	})
 
 	// When Dan Heng uses his Ultimate to defeat an enemy, he will immediately take action again.

--- a/internal/character/pela/trace.go
+++ b/internal/character/pela/trace.go
@@ -30,6 +30,7 @@ func init() {
 				}
 			},
 		},
+		CanModifySnapshot: true,
 	})
 
 	modifier.Register(A4, modifier.Config{

--- a/internal/character/silverwolf/eidolon.go
+++ b/internal/character/silverwolf/eidolon.go
@@ -43,6 +43,7 @@ func init() {
 				e.Hit.Attacker.AddProperty(E6, prop.AllDamagePercent, 0.2*float64(debuffCount))
 			},
 		},
+		CanModifySnapshot: true,
 	})
 }
 

--- a/internal/lightcone/destruction/asecretvow/asecretvow.go
+++ b/internal/lightcone/destruction/asecretvow/asecretvow.go
@@ -29,6 +29,7 @@ func init() {
 		Listeners: modifier.Listeners{
 			OnBeforeHitAll: onBeforeHitAll,
 		},
+		CanModifySnapshot: true,
 	})
 }
 

--- a/internal/lightcone/destruction/shatteredhome/shatteredhome.go
+++ b/internal/lightcone/destruction/shatteredhome/shatteredhome.go
@@ -27,6 +27,7 @@ func init() {
 		Listeners: modifier.Listeners{
 			OnBeforeHitAll: onBeforeHitAll,
 		},
+		CanModifySnapshot: true,
 	})
 }
 

--- a/internal/lightcone/hunt/cruisinginthestellarsea/cruisinginthestellarsea.go
+++ b/internal/lightcone/hunt/cruisinginthestellarsea/cruisinginthestellarsea.go
@@ -37,6 +37,7 @@ func init() {
 			OnBeforeHitAll: onBeforeHitAll,
 			OnTriggerDeath: onTriggerDeath,
 		},
+		CanModifySnapshot: true,
 	})
 
 	modifier.Register(CruisingintheStellarSeaATKBuff, modifier.Config{

--- a/internal/lightcone/nihility/incessantrain/incessantrain.go
+++ b/internal/lightcone/nihility/incessantrain/incessantrain.go
@@ -41,6 +41,7 @@ func init() {
 			OnAfterAttack:  fetchHitEnemies,
 			OnAfterAction:  applyDebuffOnce,
 		},
+		CanModifySnapshot: true,
 	})
 	modifier.Register(code, modifier.Config{
 		StatusType: model.StatusType_STATUS_DEBUFF,

--- a/internal/lightcone/nihility/loop/loop.go
+++ b/internal/lightcone/nihility/loop/loop.go
@@ -28,6 +28,7 @@ func init() {
 		Listeners: modifier.Listeners{
 			OnBeforeHitAll: boostDmgOnSlowed,
 		},
+		CanModifySnapshot: true,
 	})
 }
 


### PR DESCRIPTION
These changes are related to issue #176.
changes applied to merged PRs only. Unchanged :
- Good Night Sleep Well
- Fermata
- Woof! Walk Time!
All above LCs have `OnSnapshotCreate` removed but has the new `ModifyDotDamageData` behavior flag. so no changes needed as both are equivalent.