### PR TITLE
Update impls with `CanDispel` + bugfixes to Buffs/Debuffs

### DIFF
--- a/internal/character/asta/ult.go
+++ b/internal/character/asta/ult.go
@@ -17,6 +17,7 @@ func init() {
 		Stacking:      modifier.ReplaceBySource,
 		StatusType:    model.StatusType_STATUS_BUFF,
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_SPEED_UP},
+		CanDispel:     true,
 		Duration:      2,
 	})
 }

--- a/internal/character/bronya/eidolon.go
+++ b/internal/character/bronya/eidolon.go
@@ -32,8 +32,11 @@ func init() {
 	})
 
 	modifier.Register(E2Buff, modifier.Config{
-		StatusType: model.StatusType_STATUS_BUFF,
-		Duration:   1,
+		StatusType:    model.StatusType_STATUS_BUFF,
+		Stacking:      modifier.ReplaceBySource,
+		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_SPEED_UP},
+		CanDispel:     true,
+		Duration:      1,
 	})
 
 	modifier.Register(E4Cooldown, modifier.Config{

--- a/internal/character/bronya/skill.go
+++ b/internal/character/bronya/skill.go
@@ -15,6 +15,8 @@ const (
 func init() {
 	modifier.Register(Skill, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
+		Stacking:   modifier.ReplaceBySource,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/character/bronya/technique.go
+++ b/internal/character/bronya/technique.go
@@ -15,6 +15,7 @@ const (
 func init() {
 	modifier.Register(Technique, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 		Listeners: modifier.Listeners{
 			OnAdd: func(mod *modifier.Instance) {
 				mod.SetProperty(prop.ATKPercent, 0.15)

--- a/internal/character/bronya/trace.go
+++ b/internal/character/bronya/trace.go
@@ -30,6 +30,8 @@ func init() {
 	// A4 Register
 	modifier.Register(A4, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
+		Stacking:   modifier.ReplaceBySource,
+		CanDispel:  true,
 		Listeners: modifier.Listeners{
 			OnAdd: func(mod *modifier.Instance) {
 				mod.SetProperty(prop.DEFPercent, 0.2)

--- a/internal/character/bronya/ult.go
+++ b/internal/character/bronya/ult.go
@@ -15,6 +15,8 @@ const (
 func init() {
 	modifier.Register(Ult, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
+		Stacking:   modifier.ReplaceBySource,
+		CanDispel:  true,
 		Duration:   2,
 	})
 }

--- a/internal/character/clara/eidolon.go
+++ b/internal/character/clara/eidolon.go
@@ -19,11 +19,13 @@ func init() {
 	modifier.Register(E2, modifier.Config{
 		Stacking:   modifier.Refresh,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 
 	modifier.Register(E4Buff, modifier.Config{
 		TickMoment: modifier.ModifierPhase1End,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 
 	modifier.Register(E4, modifier.Config{

--- a/internal/character/clara/technique.go
+++ b/internal/character/clara/technique.go
@@ -15,6 +15,7 @@ const (
 func init() {
 	modifier.Register(Technique, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 		Duration:   2,
 	})
 }

--- a/internal/character/clara/ult.go
+++ b/internal/character/clara/ult.go
@@ -18,6 +18,7 @@ func init() {
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_BURST},
 		Stacking:      modifier.Refresh,
 		StatusType:    model.StatusType_STATUS_BUFF,
+		CanDispel:     true,
 		Duration:      2,
 	})
 

--- a/internal/character/danheng/skill.go
+++ b/internal/character/danheng/skill.go
@@ -19,6 +19,7 @@ func init() {
 	modifier.Register(SkillSpeedDown, modifier.Config{
 		Stacking:      modifier.ReplaceBySource,
 		StatusType:    model.StatusType_STATUS_DEBUFF,
+		CanDispel:     true,
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_SPEED_DOWN},
 	})
 

--- a/internal/character/danheng/talent.go
+++ b/internal/character/danheng/talent.go
@@ -22,6 +22,7 @@ type talentState struct {
 func init() {
 	modifier.Register(Talent, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 		Listeners: modifier.Listeners{
 			OnBeforeHitAll: talentBeforeHitAll,
 			OnAfterAction:  talentAfterAction,

--- a/internal/character/danheng/technique.go
+++ b/internal/character/danheng/technique.go
@@ -19,6 +19,7 @@ func init() {
 	modifier.Register(Technique, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/character/danheng/trace.go
+++ b/internal/character/danheng/trace.go
@@ -43,6 +43,7 @@ func init() {
 	modifier.Register(A4, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_STAT_SPEED_UP,
 		},

--- a/internal/character/danhengimbibitorlunae/eidolon.go
+++ b/internal/character/danhengimbibitorlunae/eidolon.go
@@ -27,6 +27,7 @@ func init() {
 		CountAddWhenStack: 1,
 		CanModifySnapshot: true,
 		Stacking:          modifier.ReplaceBySource,
+		CanDispel:         true,
 		Listeners: modifier.Listeners{
 			OnBeforeHitAll: E6OnHit,
 		},

--- a/internal/character/danhengimbibitorlunae/skill.go
+++ b/internal/character/danhengimbibitorlunae/skill.go
@@ -23,6 +23,7 @@ func (c *char) initSkill() {
 	modifier.Register(SkillEffect, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
 		Stacking:   modifier.ReplaceBySource,
+		CanDispel:  true,
 		MaxCount:   4,
 		Listeners: modifier.Listeners{
 			OnAdd: SkillOnAdd,

--- a/internal/character/danhengimbibitorlunae/talent.go
+++ b/internal/character/danhengimbibitorlunae/talent.go
@@ -19,6 +19,7 @@ func (c *char) initTalent() {
 	modifier.Register(Talent, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
 		Stacking:   modifier.ReplaceBySource,
+		CanDispel:  true,
 		MaxCount:   6,
 		Listeners: modifier.Listeners{
 			OnAdd: talentOnAdd,

--- a/internal/character/danhengimbibitorlunae/trace.go
+++ b/internal/character/danhengimbibitorlunae/trace.go
@@ -16,9 +16,7 @@ const (
 )
 
 func (c *char) initTraces() {
-	modifier.Register(A4, modifier.Config{
-		StatusType: model.StatusType_STATUS_BUFF,
-	})
+	modifier.Register(A4, modifier.Config{})
 	modifier.Register(A6, modifier.Config{
 		StatusType: model.StatusType_UNKNOWN_STATUS,
 		Listeners: modifier.Listeners{

--- a/internal/character/gallagher/attack.go
+++ b/internal/character/gallagher/attack.go
@@ -23,6 +23,7 @@ func init() {
 	modifier.Register(AtkReduction, modifier.Config{
 		StatusType: model.StatusType_STATUS_DEBUFF,
 		Stacking:   modifier.ReplaceBySource,
+		CanDispel:  true,
 		Duration:   2,
 	})
 }

--- a/internal/character/gallagher/eidolon.go
+++ b/internal/character/gallagher/eidolon.go
@@ -20,6 +20,7 @@ func init() {
 	modifier.Register(E2, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
 		Stacking:   modifier.ReplaceBySource,
+		CanDispel:  true,
 		Duration:   2,
 	})
 

--- a/internal/character/gepard/eidolon.go
+++ b/internal/character/gepard/eidolon.go
@@ -20,6 +20,7 @@ func init() {
 		Stacking:      modifier.Replace,
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_SPEED_DOWN},
 		StatusType:    model.StatusType_STATUS_DEBUFF,
+		CanDispel:     true,
 		Duration:      1,
 	})
 

--- a/internal/character/gepard/technique.go
+++ b/internal/character/gepard/technique.go
@@ -16,6 +16,7 @@ func init() {
 	modifier.Register(Technique, modifier.Config{
 		Duration:   2,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 		Listeners: modifier.Listeners{
 			OnAdd: func(mod *modifier.Instance) {
 				mod.Engine().AddShield(TechniqueShield, info.Shield{

--- a/internal/character/gepard/ult.go
+++ b/internal/character/gepard/ult.go
@@ -20,6 +20,8 @@ func init() {
 	modifier.Register(Ult, modifier.Config{
 		Duration:   3,
 		StatusType: model.StatusType_STATUS_BUFF,
+		Stacking:   modifier.Replace,
+		CanDispel:  true,
 		Listeners: modifier.Listeners{
 			OnAdd: func(mod *modifier.Instance) {
 				mod.Engine().AddShield(Ult, info.Shield{

--- a/internal/character/guinaifen/skill.go
+++ b/internal/character/guinaifen/skill.go
@@ -16,6 +16,7 @@ const (
 func init() {
 	modifier.Register(E1, modifier.Config{
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/character/herta/technique.go
+++ b/internal/character/herta/technique.go
@@ -16,6 +16,7 @@ func init() {
 	modifier.Register(technique, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/character/himeko/eidolon.go
+++ b/internal/character/himeko/eidolon.go
@@ -15,8 +15,11 @@ const (
 
 func init() {
 	modifier.Register(e1, modifier.Config{
-		Duration:   2,
-		StatusType: model.StatusType_STATUS_BUFF,
+		StatusType:    model.StatusType_STATUS_BUFF,
+		Stacking:      modifier.ReplaceBySource,
+		CanDispel:     true,
+		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_SPEED_UP},
+		Duration:      2,
 	})
 
 	modifier.Register(e2, modifier.Config{

--- a/internal/character/huohuo/talent.go
+++ b/internal/character/huohuo/talent.go
@@ -19,6 +19,7 @@ func init() {
 	modifier.Register(TalentBuff, modifier.Config{
 		Stacking:   modifier.Replace,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 		Listeners: modifier.Listeners{
 			OnPhase1: RunTalent,
 			OnBeforeAction: func(mod *modifier.Instance, e event.ActionStart) {

--- a/internal/character/huohuo/technique.go
+++ b/internal/character/huohuo/technique.go
@@ -16,6 +16,7 @@ func init() {
 	modifier.Register(TechDebuff, modifier.Config{
 		Stacking:   modifier.Replace,
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/character/huohuo/ult.go
+++ b/internal/character/huohuo/ult.go
@@ -15,9 +15,10 @@ const (
 
 func init() {
 	modifier.Register(UltBuff, modifier.Config{
-		Stacking:   modifier.Replace,
+		Stacking:   modifier.ReplaceBySource,
 		Duration:   2,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/character/kafka/eidolon.go
+++ b/internal/character/kafka/eidolon.go
@@ -17,13 +17,15 @@ const (
 func init() {
 	modifier.Register(E1, modifier.Config{
 		Listeners: modifier.Listeners{
-			OnBeforeHitAll: E1Listener,
+			OnBeforeBeingHitAll: E1Listener,
 		},
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 	})
 
 	modifier.Register(E2, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 
 	modifier.Register(E4, modifier.Config{
@@ -47,7 +49,7 @@ func (c *char) initEidolons() {
 
 func E1Listener(mod *modifier.Instance, e event.HitStart) {
 	if e.Hit.AttackType == model.AttackType_DOT {
-		e.Hit.Attacker.AddProperty(E1, prop.AllDamageTaken, 0.30)
+		e.Hit.Defender.AddProperty(E1, prop.AllDamageTaken, 0.30)
 	}
 }
 

--- a/internal/character/luka/eidolon.go
+++ b/internal/character/luka/eidolon.go
@@ -19,6 +19,7 @@ func init() {
 		Stacking:   modifier.ReplaceBySource,
 		Count:      1,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 
 	modifier.Register(e4, modifier.Config{

--- a/internal/character/luka/ult.go
+++ b/internal/character/luka/ult.go
@@ -19,6 +19,7 @@ func init() {
 			Stacking:   modifier.ReplaceBySource,
 			Duration:   3,
 			StatusType: model.StatusType_STATUS_DEBUFF,
+			CanDispel:  true,
 		},
 	)
 }

--- a/internal/character/march7th/skill.go
+++ b/internal/character/march7th/skill.go
@@ -25,6 +25,7 @@ func init() {
 		StatusType: model.StatusType_STATUS_BUFF,
 		Duration:   3,
 		Stacking:   modifier.Replace,
+		CanDispel:  true,
 		Listeners: modifier.Listeners{
 			OnAdd: func(mod *modifier.Instance) {
 				mod.Engine().AddShield(Skill, info.Shield{

--- a/internal/character/natasha/eidolon.go
+++ b/internal/character/natasha/eidolon.go
@@ -47,6 +47,7 @@ func init() {
 		},
 		TickMoment: modifier.ModifierPhase1End,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 
 	// Register E4

--- a/internal/character/natasha/skill.go
+++ b/internal/character/natasha/skill.go
@@ -21,6 +21,7 @@ func init() {
 			Stacking:          modifier.ReplaceBySource,
 			StatusType:        model.StatusType_STATUS_BUFF,
 			CanModifySnapshot: true,
+			CanDispel:         true,
 			Listeners: modifier.Listeners{
 				OnPhase1: natHot,
 			},

--- a/internal/character/natasha/technique.go
+++ b/internal/character/natasha/technique.go
@@ -16,9 +16,10 @@ const (
 func init() {
 	modifier.Register(Technique, modifier.Config{
 		StatusType:    model.StatusType_STATUS_DEBUFF,
-		Duration:      1,
-		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_FATIGUE},
 		Stacking:      modifier.ReplaceBySource,
+		CanDispel:     true,
+		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_FATIGUE},
+		Duration:      1,
 	})
 }
 

--- a/internal/character/pela/eidolon.go
+++ b/internal/character/pela/eidolon.go
@@ -21,6 +21,7 @@ func init() {
 	modifier.Register(E2, modifier.Config{
 		Stacking:      modifier.ReplaceBySource,
 		StatusType:    model.StatusType_STATUS_BUFF,
+		CanDispel:     true,
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_SPEED_UP},
 	})
 
@@ -29,6 +30,7 @@ func init() {
 		TickMoment: modifier.ModifierPhase1End,
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 	})
 
 	// When Pela attacks a debuffed enemy, she deals Additional Ice DMG equal to 40% of Pela's ATK to the enemy.

--- a/internal/character/pela/technique.go
+++ b/internal/character/pela/technique.go
@@ -18,6 +18,7 @@ func init() {
 		TickMoment:    modifier.ModifierPhase1End,
 		Stacking:      modifier.ReplaceBySource,
 		StatusType:    model.StatusType_STATUS_DEBUFF,
+		CanDispel:     true,
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_DEF_DOWN},
 	})
 }

--- a/internal/character/pela/ult.go
+++ b/internal/character/pela/ult.go
@@ -17,6 +17,7 @@ func init() {
 	modifier.Register(UltDefDown, modifier.Config{
 		Stacking:      modifier.ReplaceBySource,
 		StatusType:    model.StatusType_STATUS_DEBUFF,
+		CanDispel:     true,
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_DEF_DOWN},
 	})
 }

--- a/internal/character/qingque/skill.go
+++ b/internal/character/qingque/skill.go
@@ -20,6 +20,7 @@ func init() {
 	modifier.Register(Skill, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
 		Stacking:   modifier.ReplaceBySource,
+		CanDispel:  true,
 		MaxCount:   4,
 		Listeners: modifier.Listeners{
 			OnAdd:    skillOnAdd,

--- a/internal/character/qingque/talent.go
+++ b/internal/character/qingque/talent.go
@@ -16,6 +16,7 @@ const (
 func init() {
 	modifier.Register(Talent, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
+		Stacking:   modifier.ReplaceBySource,
 	})
 }
 

--- a/internal/character/qingque/trace.go
+++ b/internal/character/qingque/trace.go
@@ -30,6 +30,7 @@ func init() {
 	modifier.Register(A6, modifier.Config{
 		StatusType:    model.StatusType_STATUS_BUFF,
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_SPEED_UP},
+		CanDispel:     true,
 	})
 }
 

--- a/internal/character/sampo/ult.go
+++ b/internal/character/sampo/ult.go
@@ -18,6 +18,7 @@ func init() {
 	modifier.Register(SampoDOTTaken, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 		Listeners: modifier.Listeners{
 			OnBeforeBeingHitAll: onBeforeBeingHitAll,
 		},

--- a/internal/character/seele/skill.go
+++ b/internal/character/seele/skill.go
@@ -21,6 +21,7 @@ func init() {
 		Stacking:          modifier.ReplaceBySource,
 		StatusType:        model.StatusType_STATUS_BUFF,
 		BehaviorFlags:     []model.BehaviorFlag{model.BehaviorFlag_STAT_SPEED_UP},
+		CanDispel:         true,
 		CountAddWhenStack: 1,
 	})
 }

--- a/internal/character/seele/talent.go
+++ b/internal/character/seele/talent.go
@@ -23,6 +23,7 @@ func init() {
 	modifier.Register(Resurgence, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/character/silverwolf/eidolon.go
+++ b/internal/character/silverwolf/eidolon.go
@@ -31,9 +31,6 @@ func init() {
 
 	// For every debuff the target enemy has, the DMG dealt by Silver Wolf increases by 20%, up to a limit of 100%.
 	modifier.Register(E6, modifier.Config{
-		TickMoment: modifier.ModifierPhase1End,
-		Stacking:   modifier.ReplaceBySource,
-		StatusType: model.StatusType_STATUS_DEBUFF,
 		Listeners: modifier.Listeners{
 			OnBeforeHitAll: func(mod *modifier.Instance, e event.HitStart) {
 				debuffCount := mod.Engine().ModifierStatusCount(e.Defender, model.StatusType_STATUS_DEBUFF)
@@ -43,7 +40,6 @@ func init() {
 				e.Hit.Attacker.AddProperty(E6, prop.AllDamagePercent, 0.2*float64(debuffCount))
 			},
 		},
-		CanModifySnapshot: true,
 	})
 }
 

--- a/internal/character/silverwolf/skill.go
+++ b/internal/character/silverwolf/skill.go
@@ -31,12 +31,14 @@ func init() {
 		TickMoment: modifier.ModifierPhase1End,
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 	})
 
 	modifier.Register(SkillWeakType, modifier.Config{
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_ATTACH_WEAKNESS},
 		Stacking:      modifier.Replace,
 		StatusType:    model.StatusType_STATUS_DEBUFF,
+		CanDispel:     true,
 		Listeners: modifier.Listeners{
 			OnAdd: func(mod *modifier.Instance) {
 				dmgType, ok := chooseWeaknessType(mod.Engine(), mod.Owner())

--- a/internal/character/silverwolf/talent.go
+++ b/internal/character/silverwolf/talent.go
@@ -21,6 +21,7 @@ func init() {
 	modifier.Register(BugATK, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 		Listeners: modifier.Listeners{
 			OnAdd: func(mod *modifier.Instance) {
 				char, _ := mod.Engine().CharacterInfo(mod.Source())
@@ -33,6 +34,7 @@ func init() {
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_DEF_DOWN},
 		Stacking:      modifier.ReplaceBySource,
 		StatusType:    model.StatusType_STATUS_DEBUFF,
+		CanDispel:     true,
 		Listeners: modifier.Listeners{
 			OnAdd: func(mod *modifier.Instance) {
 				char, _ := mod.Engine().CharacterInfo(mod.Source())
@@ -45,6 +47,7 @@ func init() {
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_SPEED_DOWN},
 		Stacking:      modifier.ReplaceBySource,
 		StatusType:    model.StatusType_STATUS_DEBUFF,
+		CanDispel:     true,
 		Listeners: modifier.Listeners{
 			OnAdd: func(mod *modifier.Instance) {
 				char, _ := mod.Engine().CharacterInfo(mod.Source())

--- a/internal/character/silverwolf/ult.go
+++ b/internal/character/silverwolf/ult.go
@@ -19,6 +19,7 @@ func init() {
 		Stacking:      modifier.ReplaceBySource,
 		StatusType:    model.StatusType_STATUS_DEBUFF,
 		TickMoment:    modifier.ModifierPhase1End,
+		CanDispel:     true,
 	})
 }
 

--- a/internal/character/sushang/talent.go
+++ b/internal/character/sushang/talent.go
@@ -17,6 +17,7 @@ func init() {
 	modifier.Register(TalentBuff, modifier.Config{
 		Stacking:      modifier.ReplaceBySource,
 		StatusType:    model.StatusType_STATUS_BUFF,
+		CanDispel:     true,
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_SPEED_UP},
 		Listeners: modifier.Listeners{
 			OnAdd: talentOnAdd,

--- a/internal/character/sushang/trace.go
+++ b/internal/character/sushang/trace.go
@@ -40,6 +40,7 @@ func init() {
 	// A2 aggro down buff
 	modifier.Register(A2Buff, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
+		Stacking:   modifier.ReplaceBySource,
 	})
 
 	// applies a4 buff

--- a/internal/character/sushang/ult.go
+++ b/internal/character/sushang/ult.go
@@ -16,6 +16,7 @@ func init() {
 	modifier.Register(Ult, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/character/xueyi/eidolon.go
+++ b/internal/character/xueyi/eidolon.go
@@ -25,6 +25,7 @@ func init() {
 		Stacking:   modifier.ReplaceBySource,
 		Duration:   2,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/global/common/bleed.go
+++ b/internal/global/common/bleed.go
@@ -30,6 +30,7 @@ func init() {
 		MaxCount:          1,
 		CountAddWhenStack: 1,
 		StatusType:        model.StatusType_STATUS_DEBUFF,
+		CanDispel:         true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_STAT_DOT,
 			model.BehaviorFlag_STAT_DOT_BLEED,
@@ -46,6 +47,7 @@ func init() {
 		MaxCount:          1,
 		CountAddWhenStack: 1,
 		StatusType:        model.StatusType_STATUS_DEBUFF,
+		CanDispel:         true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_STAT_DOT,
 			model.BehaviorFlag_STAT_DOT_BLEED,

--- a/internal/global/common/burn.go
+++ b/internal/global/common/burn.go
@@ -31,6 +31,7 @@ func init() {
 		MaxCount:          1,
 		CountAddWhenStack: 1,
 		StatusType:        model.StatusType_STATUS_DEBUFF,
+		CanDispel:         true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_STAT_DOT,
 			model.BehaviorFlag_STAT_DOT_BURN,
@@ -47,6 +48,7 @@ func init() {
 		MaxCount:          1,
 		CountAddWhenStack: 1,
 		StatusType:        model.StatusType_STATUS_DEBUFF,
+		CanDispel:         true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_STAT_DOT,
 			model.BehaviorFlag_STAT_DOT_BURN,

--- a/internal/global/common/entangle.go
+++ b/internal/global/common/entangle.go
@@ -33,6 +33,7 @@ func init() {
 		Duration:   1,
 		Count:      1,
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_DISABLE_ACTION,
 			model.BehaviorFlag_STAT_ENTANGLE,
@@ -52,6 +53,7 @@ func init() {
 		Duration:   1,
 		Count:      1,
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_DISABLE_ACTION,
 			model.BehaviorFlag_STAT_ENTANGLE,

--- a/internal/global/common/freeze.go
+++ b/internal/global/common/freeze.go
@@ -21,6 +21,7 @@ func init() {
 	modifier.Register(Freeze, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_DISABLE_ACTION,
 			model.BehaviorFlag_STAT_CTRL,
@@ -34,6 +35,7 @@ func init() {
 	modifier.Register(BreakFreeze, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_DISABLE_ACTION,
 			model.BehaviorFlag_STAT_CTRL,

--- a/internal/global/common/imprison.go
+++ b/internal/global/common/imprison.go
@@ -23,6 +23,7 @@ func init() {
 		Stacking:   modifier.ReplaceBySource,
 		TickMoment: modifier.ModifierPhase1End,
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_DISABLE_ACTION,
 			model.BehaviorFlag_STAT_CTRL,
@@ -39,6 +40,7 @@ func init() {
 		Stacking:   modifier.ReplaceBySource,
 		TickMoment: modifier.ModifierPhase1End,
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_DISABLE_ACTION,
 			model.BehaviorFlag_STAT_CTRL,

--- a/internal/global/common/shock.go
+++ b/internal/global/common/shock.go
@@ -31,6 +31,7 @@ func init() {
 		MaxCount:          1,
 		CountAddWhenStack: 1,
 		StatusType:        model.StatusType_STATUS_DEBUFF,
+		CanDispel:         true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_STAT_DOT,
 			model.BehaviorFlag_STAT_DOT_ELECTRIC,
@@ -47,6 +48,7 @@ func init() {
 		MaxCount:          1,
 		CountAddWhenStack: 1,
 		StatusType:        model.StatusType_STATUS_DEBUFF,
+		CanDispel:         true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_STAT_DOT,
 			model.BehaviorFlag_STAT_DOT_ELECTRIC,

--- a/internal/global/common/wind.go
+++ b/internal/global/common/wind.go
@@ -28,6 +28,7 @@ func init() {
 		MaxCount:          5,
 		CountAddWhenStack: 1,
 		StatusType:        model.StatusType_STATUS_DEBUFF,
+		CanDispel:         true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_STAT_DOT,
 			model.BehaviorFlag_STAT_DOT_POISON,
@@ -44,6 +45,7 @@ func init() {
 		MaxCount:          5,
 		CountAddWhenStack: 1,
 		StatusType:        model.StatusType_STATUS_DEBUFF,
+		CanDispel:         true,
 		BehaviorFlags: []model.BehaviorFlag{
 			model.BehaviorFlag_STAT_DOT,
 			model.BehaviorFlag_STAT_DOT_POISON,

--- a/internal/lightcone/abundance/cornucopia/cornucopia.go
+++ b/internal/lightcone/abundance/cornucopia/cornucopia.go
@@ -30,10 +30,8 @@ func init() {
 			OnAfterAction:  removeHealBuff,
 		},
 	})
-	// The actual buff modifier goes here
-	modifier.Register(CornucopiaBuff, modifier.Config{
-		StatusType: model.StatusType_STATUS_BUFF,
-	})
+	// The actual modifier goes here
+	modifier.Register(CornucopiaBuff, modifier.Config{})
 }
 
 // When the wearer uses their Skill or Ultimate, their Outgoing Healing increases by 12%(S1)

--- a/internal/lightcone/abundance/echoesofthecoffin/echoesofthecoffin.go
+++ b/internal/lightcone/abundance/echoesofthecoffin/echoesofthecoffin.go
@@ -42,6 +42,7 @@ func init() {
 	modifier.Register(spdBuff, modifier.Config{
 		Stacking:      modifier.ReplaceBySource,
 		StatusType:    model.StatusType_STATUS_BUFF,
+		CanDispel:     true,
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_SPEED_UP},
 	})
 }

--- a/internal/lightcone/abundance/heyoverhere/heyoverhere.go
+++ b/internal/lightcone/abundance/heyoverhere/heyoverhere.go
@@ -35,6 +35,7 @@ func init() {
 	modifier.Register(HeyOverHereBuff, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/lightcone/destruction/mutualdemise/mutualdemise.go
+++ b/internal/lightcone/destruction/mutualdemise/mutualdemise.go
@@ -35,6 +35,8 @@ func init() {
 
 	modifier.Register(MutualDemiseBuff, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
+		Stacking:   modifier.ReplaceBySource,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/lightcone/destruction/onthefallofanaeon/onthefallofanaeon.go
+++ b/internal/lightcone/destruction/onthefallofanaeon/onthefallofanaeon.go
@@ -43,6 +43,7 @@ func init() {
 	modifier.Register(BuffAtk, modifier.Config{
 		StatusType:        model.StatusType_STATUS_BUFF,
 		Stacking:          modifier.ReplaceBySource,
+		CanDispel:         true,
 		MaxCount:          4,
 		CountAddWhenStack: 1,
 		Listeners: modifier.Listeners{
@@ -53,6 +54,7 @@ func init() {
 	modifier.Register(BuffDmgBonus, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
 		Stacking:   modifier.ReplaceBySource,
+		CanDispel:  true,
 		Duration:   2,
 	})
 }

--- a/internal/lightcone/destruction/themoleswelcomeyou/themoleswelcomeyou.go
+++ b/internal/lightcone/destruction/themoleswelcomeyou/themoleswelcomeyou.go
@@ -42,6 +42,7 @@ func init() {
 		CountAddWhenStack: 1,
 		Stacking:          modifier.ReplaceBySource,
 		StatusType:        model.StatusType_STATUS_BUFF,
+		CanDispel:         true,
 		Listeners: modifier.Listeners{
 			OnAdd: buffOnAdd,
 		},

--- a/internal/lightcone/destruction/theunreachableside/theunreachableside.go
+++ b/internal/lightcone/destruction/theunreachableside/theunreachableside.go
@@ -38,6 +38,7 @@ func init() {
 			OnAfterAttack: removeBuff,
 		},
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/lightcone/destruction/underthebluesky/underthebluesky.go
+++ b/internal/lightcone/destruction/underthebluesky/underthebluesky.go
@@ -32,6 +32,7 @@ func init() {
 	modifier.Register(Buff, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
 		Stacking:   modifier.Replace,
+		CanDispel:  true,
 		Duration:   3,
 	})
 }

--- a/internal/lightcone/destruction/whereaboutsshoulddreamsrest/whereaboutsshoulddreamsrest.go
+++ b/internal/lightcone/destruction/whereaboutsshoulddreamsrest/whereaboutsshoulddreamsrest.go
@@ -30,6 +30,7 @@ func init() {
 	modifier.Register(routed, modifier.Config{
 		Stacking:   modifier.Replace,
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 		Listeners: modifier.Listeners{
 			OnBeforeHitAll: onBeforeHitAll,
 		},

--- a/internal/lightcone/erudition/afterthecharmonyfall/afterthecharmonyfall.go
+++ b/internal/lightcone/erudition/afterthecharmonyfall/afterthecharmonyfall.go
@@ -29,6 +29,7 @@ func init() {
 	modifier.Register(charmonyFallSpd, modifier.Config{
 		Stacking:      modifier.ReplaceBySource,
 		StatusType:    model.StatusType_STATUS_BUFF,
+		CanDispel:     true,
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_SPEED_UP},
 		Listeners: modifier.Listeners{
 			OnAfterAction: addSpdBuff,

--- a/internal/lightcone/erudition/beforedawn/beforedawn.go
+++ b/internal/lightcone/erudition/beforedawn/beforedawn.go
@@ -41,6 +41,7 @@ func init() {
 
 	modifier.Register(SomnusCorpus, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 		Listeners: modifier.Listeners{
 			OnBeforeHit:   onBeforeHitSomnus,
 			OnAfterAttack: onAfterAttack,

--- a/internal/lightcone/erudition/geniusesrepose/geniusesrepose.go
+++ b/internal/lightcone/erudition/geniusesrepose/geniusesrepose.go
@@ -33,6 +33,7 @@ func init() {
 	modifier.Register(buff, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/lightcone/erudition/nightonthemilkyway/nightonthemilkyway.go
+++ b/internal/lightcone/erudition/nightonthemilkyway/nightonthemilkyway.go
@@ -27,11 +27,11 @@ func init() {
 	modifier.Register(dmgBuff, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
 		Stacking:   modifier.ReplaceBySource,
+		CanDispel:  true,
 	})
 	// Since the atkBuff method just calculates the entire atk bonus each time I don't think this needs the maxCount
 	modifier.Register(NightontheMilkyWay, modifier.Config{
-		StatusType: model.StatusType_STATUS_BUFF,
-		Stacking:   modifier.ReplaceBySource,
+		Stacking: modifier.ReplaceBySource,
 	})
 }
 

--- a/internal/lightcone/erudition/sagacity/sagacity.go
+++ b/internal/lightcone/erudition/sagacity/sagacity.go
@@ -33,6 +33,7 @@ func init() {
 	modifier.Register(sagacity, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/lightcone/erudition/thedaythecosmosfell/thedaythecosmosfell.go
+++ b/internal/lightcone/erudition/thedaythecosmosfell/thedaythecosmosfell.go
@@ -29,6 +29,7 @@ func init() {
 	modifier.Register(cosmosCritDmg, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 		Listeners: modifier.Listeners{
 			OnAfterAttack: weaknessCheck,
 		},

--- a/internal/lightcone/erudition/theseriousnessofbreakfast/theseriousnessofbreakfast.go
+++ b/internal/lightcone/erudition/theseriousnessofbreakfast/theseriousnessofbreakfast.go
@@ -35,6 +35,7 @@ func init() {
 	modifier.Register(Buff, modifier.Config{
 		StatusType:        model.StatusType_STATUS_BUFF,
 		Stacking:          modifier.ReplaceBySource,
+		CanDispel:         true,
 		MaxCount:          3,
 		CountAddWhenStack: 1,
 		Listeners: modifier.Listeners{

--- a/internal/lightcone/harmony/carvethemoonweavetheclouds/carvethemoonweavetheclouds.go
+++ b/internal/lightcone/harmony/carvethemoonweavetheclouds/carvethemoonweavetheclouds.go
@@ -50,14 +50,17 @@ func init() {
 	modifier.Register(carveAtk, modifier.Config{
 		Stacking:   modifier.Replace,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 	modifier.Register(carveCDmg, modifier.Config{
 		Stacking:   modifier.Replace,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 	modifier.Register(carveERR, modifier.Config{
 		Stacking:   modifier.Replace,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/lightcone/hunt/adversarial/adversarial.go
+++ b/internal/lightcone/hunt/adversarial/adversarial.go
@@ -34,6 +34,7 @@ func init() {
 	modifier.Register(AdversarialBuff, modifier.Config{
 		Stacking:      modifier.ReplaceBySource,
 		StatusType:    model.StatusType_STATUS_BUFF,
+		CanDispel:     true,
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_SPEED_UP},
 	})
 }

--- a/internal/lightcone/hunt/arrows/arrows.go
+++ b/internal/lightcone/hunt/arrows/arrows.go
@@ -26,6 +26,7 @@ func init() {
 
 	modifier.Register(Arrows, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/lightcone/hunt/cruisinginthestellarsea/cruisinginthestellarsea.go
+++ b/internal/lightcone/hunt/cruisinginthestellarsea/cruisinginthestellarsea.go
@@ -43,6 +43,7 @@ func init() {
 	modifier.Register(CruisingintheStellarSeaATKBuff, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/lightcone/hunt/dartingarrow/dartingarrow.go
+++ b/internal/lightcone/hunt/dartingarrow/dartingarrow.go
@@ -33,6 +33,7 @@ func init() {
 	modifier.Register(DartingArrowBuff, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/lightcone/hunt/riverflowsinspring/riverflowsinspring.go
+++ b/internal/lightcone/hunt/riverflowsinspring/riverflowsinspring.go
@@ -42,6 +42,7 @@ func init() {
 	modifier.Register(RiverFlowsinSpringBuff, modifier.Config{
 		BehaviorFlags: []model.BehaviorFlag{model.BehaviorFlag_STAT_SPEED_UP},
 		StatusType:    model.StatusType_STATUS_BUFF,
+		CanDispel:     true,
 	})
 }
 

--- a/internal/lightcone/hunt/sleeplikethedead/sleeplikethedead.go
+++ b/internal/lightcone/hunt/sleeplikethedead/sleeplikethedead.go
@@ -38,6 +38,7 @@ func init() {
 	modifier.Register(Buff, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
 		Stacking:   modifier.ReplaceBySource,
+		CanDispel:  true,
 	})
 
 	modifier.Register(Cooldown, modifier.Config{})

--- a/internal/lightcone/hunt/swordplay/swordplay.go
+++ b/internal/lightcone/hunt/swordplay/swordplay.go
@@ -38,6 +38,7 @@ func init() {
 	modifier.Register(Buff, modifier.Config{
 		StatusType:        model.StatusType_STATUS_BUFF,
 		Stacking:          modifier.ReplaceBySource,
+		CanDispel:         true,
 		MaxCount:          5,
 		CountAddWhenStack: 1,
 		Listeners: modifier.Listeners{

--- a/internal/lightcone/nihility/alongthepassingshore/alongthepassingshore.go
+++ b/internal/lightcone/nihility/alongthepassingshore/alongthepassingshore.go
@@ -41,6 +41,7 @@ func init() {
 	modifier.Register(MirageFizzle, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 	})
 
 	modifier.Register(Cooldown, modifier.Config{})

--- a/internal/lightcone/nihility/incessantrain/incessantrain.go
+++ b/internal/lightcone/nihility/incessantrain/incessantrain.go
@@ -46,6 +46,7 @@ func init() {
 	modifier.Register(code, modifier.Config{
 		StatusType: model.StatusType_STATUS_DEBUFF,
 		Stacking:   modifier.Replace,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/lightcone/nihility/patienceisallyouneed/patienceisallyouneed.go
+++ b/internal/lightcone/nihility/patienceisallyouneed/patienceisallyouneed.go
@@ -46,6 +46,7 @@ func init() {
 		},
 		Stacking:          modifier.ReplaceBySource,
 		StatusType:        model.StatusType_STATUS_BUFF,
+		CanDispel:         true,
 		MaxCount:          3,
 		CountAddWhenStack: 1,
 		Listeners: modifier.Listeners{
@@ -63,6 +64,7 @@ func init() {
 		Stacking:          modifier.ReplaceBySource,
 		TickMoment:        modifier.ModifierPhase1End,
 		StatusType:        model.StatusType_STATUS_DEBUFF,
+		CanDispel:         true,
 		MaxCount:          1,
 		CountAddWhenStack: 1,
 	})

--- a/internal/lightcone/nihility/resolutionshinesaspearlsofsweat/resolutionshinesaspearlsofsweat.go
+++ b/internal/lightcone/nihility/resolutionshinesaspearlsofsweat/resolutionshinesaspearlsofsweat.go
@@ -41,6 +41,7 @@ func init() {
 			model.BehaviorFlag_STAT_DEF_DOWN,
 		},
 		StatusType: model.StatusType_STATUS_DEBUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/lightcone/preservation/textureofmemories/textureofmemories.go
+++ b/internal/lightcone/preservation/textureofmemories/textureofmemories.go
@@ -44,11 +44,13 @@ func init() {
 	})
 
 	modifier.Register(modshieldbuff, modifier.Config{
+		StatusType: model.StatusType_STATUS_BUFF,
+		Stacking:   modifier.Replace,
+		CanDispel:  true,
 		Listeners: modifier.Listeners{
 			OnAdd:    shieldBuffOnAdd,
 			OnRemove: shieldBuffOnRemove,
 		},
-		StatusType: model.StatusType_STATUS_BUFF,
 	})
 
 	modifier.Register(modcd, modifier.Config{})

--- a/internal/lightcone/preservation/wearewildfire/wearewildfire.go
+++ b/internal/lightcone/preservation/wearewildfire/wearewildfire.go
@@ -32,6 +32,7 @@ func init() {
 		Stacking:   modifier.ReplaceBySource,
 		TickMoment: modifier.ModifierPhase1End,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/relic/cavern/championboxing/championboxing.go
+++ b/internal/relic/cavern/championboxing/championboxing.go
@@ -52,6 +52,7 @@ func init() {
 		MaxCount:          5,
 		CountAddWhenStack: 1,
 		Stacking:          modifier.Replace,
+		CanDispel:         true,
 		Listeners: modifier.Listeners{
 			OnAdd: onAdd,
 		},

--- a/internal/relic/cavern/duke/duke.go
+++ b/internal/relic/cavern/duke/duke.go
@@ -67,6 +67,7 @@ func init() {
 		CountAddWhenStack: 1,
 		Duration:          3,
 		StatusType:        model.StatusType_STATUS_BUFF,
+		CanDispel:         true,
 		Listeners: modifier.Listeners{
 			OnAdd: onAddStack,
 		},

--- a/internal/relic/cavern/hunterofglacialforest/hunterofglacialforest.go
+++ b/internal/relic/cavern/hunterofglacialforest/hunterofglacialforest.go
@@ -49,6 +49,7 @@ func init() {
 	modifier.Register(buff, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 	})
 }
 

--- a/internal/relic/cavern/valorous/valorous.go
+++ b/internal/relic/cavern/valorous/valorous.go
@@ -51,6 +51,7 @@ func init() {
 	modifier.Register(buffUltDmg, modifier.Config{
 		Stacking:   modifier.ReplaceBySource,
 		StatusType: model.StatusType_STATUS_BUFF,
+		CanDispel:  true,
 		Listeners: modifier.Listeners{
 			OnBeforeHitAll: doBuffUlt,
 		},

--- a/internal/relic/planar/lushaka/lushaka.go
+++ b/internal/relic/planar/lushaka/lushaka.go
@@ -32,6 +32,7 @@ func init() {
 	modifier.Register(name, modifier.Config{
 		StatusType: model.StatusType_STATUS_BUFF,
 		Stacking:   modifier.ReplaceBySource,
+		CanDispel:  true,
 	})
 }
 


### PR DESCRIPTION
Update existing implementations with `CanDispel: true,` where needed, by checking modifiers that are Buffs or Debuffs.
There are only a handful of currently known "Dispellable Other"-type modifiers on characters (i.e., Firefly, Jade, MarchHunt) and LCs (i.e., Earthly Escapade), all of which are unimplemented at this time.

Additional notes:
* fix DHIL A4, Cornucopia (LC) with correct StatusType
* fix Silver Wolf E6 with correct StatusType/remove unnecessary fields
* fix Bronya E2 Spd Buff with correct Stacking and Flag
* fix Bronya Skill Buff/A4/Ult, Gepard Ult, Qingque Talent Atk Buff, Huohuo Ult Atk Buff, Mutual Demise (LC) with correct Stacking
* fix Kafka E1 Debuff to correctly apply damage taken increase
* Blade will be reworked in a separate PR
* Something Irreplacable (LC) will be reworked in a separate PR